### PR TITLE
Pin `nx` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "jest-environment-jsdom": "^29.7.0",
         "jest-environment-node": "^29.7.0",
         "license-checker": "^25.0.1",
-        "nx": "^17.2.8",
+        "nx": "17.2.8",
         "prettier": "3.1.1",
         "ts-jest": "29.1.1",
         "ts-node": "^10.9.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "jest-environment-node": "^29.7.0",
     "license-checker": "^25.0.1",
-    "nx": "^17.2.8",
+    "nx": "17.2.8",
     "prettier": "3.1.1",
     "ts-jest": "29.1.1",
     "ts-node": "^10.9.2",


### PR DESCRIPTION
This change makes the `nx` dep version consistent with scoped `@nx` packages.