### PR TITLE
 TokenBalance supports TokenHold locks for fungible tokens

### DIFF
--- a/chain-api/src/types/lock.ts
+++ b/chain-api/src/types/lock.ts
@@ -148,7 +148,7 @@ export class UnlockTokenDto extends ChainCallDTO {
   @ValidateIf((o) => o.tokenInstance.instance === TokenInstance.FUNGIBLE_TOKEN_INSTANCE)
   @BigNumberIsPositive()
   @BigNumberProperty()
-  quantity?: BigNumber | undefined;
+  quantity?: BigNumber;
 }
 
 @JSONSchema({

--- a/chain-api/src/types/lock.ts
+++ b/chain-api/src/types/lock.ts
@@ -14,13 +14,22 @@
  */
 import BigNumber from "bignumber.js";
 import { Type } from "class-transformer";
-import { ArrayNotEmpty, IsInt, IsNotEmpty, IsOptional, IsString, Min, ValidateNested } from "class-validator";
+import {
+  ArrayNotEmpty,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Min,
+  ValidateIf,
+  ValidateNested
+} from "class-validator";
 import { JSONSchema } from "class-validator-jsonschema";
 
 import { TokenInstance, TokenInstanceKey } from "../types/TokenInstance";
 import { ChainCallDTO } from "../types/dtos";
 import { BigNumberProperty } from "../utils";
-import { BigNumberIsNotNegative } from "../validators";
+import { BigNumberIsNotNegative, BigNumberIsPositive } from "../validators";
 import { LockTokenQuantity } from "./LockTokenQuantity";
 
 @JSONSchema({
@@ -131,6 +140,15 @@ export class UnlockTokenDto extends ChainCallDTO {
   @Type(() => TokenInstanceKey)
   @IsNotEmpty()
   tokenInstance: TokenInstanceKey;
+
+  @JSONSchema({
+    description: "Optional quantity for unlocking fungible tokens. Not for use with NFT token instances."
+  })
+  @IsOptional()
+  @ValidateIf((o) => o.tokenInstance.instance === TokenInstance.FUNGIBLE_TOKEN_INSTANCE)
+  @BigNumberIsPositive()
+  @BigNumberProperty()
+  quantity?: BigNumber | undefined;
 }
 
 @JSONSchema({

--- a/chain-cli/chaincode-template/src/token/GalaChainTokenContract.ts
+++ b/chain-cli/chaincode-template/src/token/GalaChainTokenContract.ts
@@ -440,7 +440,8 @@ export default class GalaChainTokenContract extends GalaContract {
   public async UnlockToken(ctx: GalaChainContext, dto: UnlockTokenDto): Promise<TokenBalance> {
     return unlockToken(ctx, {
       tokenInstanceKey: dto.tokenInstance,
-      name: undefined
+      name: undefined,
+      quantity: dto.quantity
     });
   }
 

--- a/chaincode/src/__test__/GalaChainTokenContract.ts
+++ b/chaincode/src/__test__/GalaChainTokenContract.ts
@@ -442,7 +442,8 @@ export default class GalaChainTokenContract extends GalaContract {
   public async UnlockToken(ctx: GalaChainContext, dto: UnlockTokenDto): Promise<TokenBalance> {
     return unlockToken(ctx, {
       tokenInstanceKey: dto.tokenInstance,
-      name: undefined
+      name: undefined,
+      quantity: dto.quantity
     });
   }
 

--- a/chaincode/src/allowances/AllowanceError.ts
+++ b/chaincode/src/allowances/AllowanceError.ts
@@ -61,10 +61,12 @@ export class InsufficientTokenBalanceError extends ValidationFailedError {
     tokenInstanceKey: string,
     allowanceType: string,
     userBalance: BigNumber,
-    allowanceQuantity: BigNumber
+    allowanceQuantity: BigNumber,
+    lockedQuantity: BigNumber
   ) {
     super(
-      `User ${callingUser} has insufficient balance ${userBalance} for token ${tokenInstanceKey} to grant ${allowanceType} allowance for quantity: ${allowanceQuantity}.`,
+      `User ${callingUser} has insufficient total balance ${userBalance} minus locked balance ${lockedQuantity} for token ` +
+        `${tokenInstanceKey} to grant ${allowanceType} allowance for quantity: ${allowanceQuantity}.`,
       { callingUser, tokenInstanceKey, allowanceType, userBalance, allowanceQuantity }
     );
   }

--- a/chaincode/src/allowances/grantAllowance.spec.ts
+++ b/chaincode/src/allowances/grantAllowance.spec.ts
@@ -149,7 +149,8 @@ describe("GrantAllowance", () => {
           currencyInstanceKey.toStringKey(),
           AllowanceType[AllowanceType.Lock],
           new BigNumber("1000"),
-          new BigNumber("1001")
+          new BigNumber("1001"),
+          new BigNumber("0")
         )
       )
     );

--- a/chaincode/src/allowances/grantAllowance.ts
+++ b/chaincode/src/allowances/grantAllowance.ts
@@ -535,13 +535,14 @@ export async function grantAllowance(
       const callingUserBalance = await fetchOrCreateBalance(ctx, ctx.callingUser, instanceClassKey);
 
       // for fungible tokens, we need to check the balance and quantities
-      if (callingUserBalance.getQuantityTotal().isLessThan(totalQuantity)) {
+      if (callingUserBalance.getSpendableQuantityTotal(ctx.txUnixTime).isLessThan(totalQuantity)) {
         throw new InsufficientTokenBalanceError(
           ctx.callingUser,
           instanceKey.toStringKey(),
           AllowanceType[allowanceType],
           callingUserBalance.getQuantityTotal(),
-          totalQuantity
+          totalQuantity,
+          callingUserBalance.getLockedQuantityTotal(ctx.txUnixTime)
         );
       }
     }

--- a/chaincode/src/burns/burnTokens.ts
+++ b/chaincode/src/burns/burnTokens.ts
@@ -190,7 +190,7 @@ export async function burnTokens(
     if (tokenInstance.isNonFungible) {
       userBalance.ensureCanRemoveInstance(tokenInstance.instance, ctx.txUnixTime).remove();
     } else {
-      userBalance.ensureCanSubtractQuantity(tokenQuantity.quantity).subtract();
+      userBalance.ensureCanSubtractQuantity(tokenQuantity.quantity, ctx.txUnixTime).subtract();
     }
 
     const newBurn = await createTokenBurn(ctx, owner, tokenQuantity.tokenInstanceKey, tokenQuantity.quantity);

--- a/chaincode/src/locks/unlockToken.ts
+++ b/chaincode/src/locks/unlockToken.ts
@@ -25,7 +25,7 @@ import { UnlockForbiddenUserError } from "./LockError";
 export interface UnlockTokenParams {
   tokenInstanceKey: TokenInstanceKey;
   name: string | undefined;
-  quantity?: BigNumber | undefined;
+  quantity: BigNumber | undefined;
 }
 
 export async function unlockToken(

--- a/chaincode/src/transfer/transferToken.ts
+++ b/chaincode/src/transfer/transferToken.ts
@@ -80,7 +80,7 @@ export async function transferToken(
     fromPersonBalance.ensureCanRemoveInstance(tokenInstance.instance, ctx.txUnixTime).remove();
     toPersonBalance.ensureCanAddInstance(tokenInstance.instance).add();
   } else {
-    fromPersonBalance.ensureCanSubtractQuantity(quantity).subtract();
+    fromPersonBalance.ensureCanSubtractQuantity(quantity, ctx.txUnixTime).subtract();
     toPersonBalance.ensureCanAddQuantity(quantity).add();
   }
 

--- a/licenses/licenses.csv
+++ b/licenses/licenses.csv
@@ -142,7 +142,7 @@
 "@gala-chain/chaincode@1.0.0","@gala-chain/chaincode","1.0.0","","Framework for building chaincodes on GalaChain","Apache-2.0"
 "@gala-chain/cli@1.0.0","@gala-chain/cli","1.0.0","","CLI for GalaChain to manage and deploy chaincodes","Apache-2.0"
 "@gala-chain/client@1.0.0","@gala-chain/client","1.0.0","","GalaChain client library","Apache-2.0"
-"@gala-chain/sdk@1.0.0","@gala-chain/sdk","1.0.0","","Welcome to developing with GalaChain! GalaChain is a layer 1 blockchain designed to be the foundation of Web3 Gaming, Entertainment and more.","UNLICENSED"
+"@gala-chain/sdk@1.0.0","@gala-chain/sdk","1.0.0","","Welcome to developing with GalaChain! GalaChain SDK is a set of TS tools to help you develop on GalaChain:","UNLICENSED"
 "@gala-chain/test@1.0.0","@gala-chain/test","1.0.0","","Unit testing and integration testing for GalaChain","Apache-2.0"
 "@gar/promisify@1.1.3","@gar/promisify","1.1.3","https://github.com/wraithgar/gar-promisify","Promisify an entire class or object","MIT"
 "@grpc/grpc-js@1.9.7","@grpc/grpc-js","1.9.7","https://github.com/grpc/grpc-node/tree/master/packages/grpc-js","gRPC Library for Node - pure JS implementation","Apache-2.0"


### PR DESCRIPTION
TokenBalance supports locks on fungible tokens and accounts for locked fungible quantity when calculating spendable balance. 

LockToken / UnlockToken methods support new locking api for fungible tokens on TokenBalance.

TokenBalance can possibly support multiple locks of varying quantities over the total overall fungible balance, and will unlock quantity using the holds that are set to expire soonest.