### PR TITLE
Fix nested object key parts

### DIFF
--- a/chain-api/src/types/ChainObject.ts
+++ b/chain-api/src/types/ChainObject.ts
@@ -91,7 +91,10 @@ export abstract class ChainObject {
     const plain = instanceToPlain(this);
     const keyParts = fields
       .sort((a, b) => a.position - b.position)
-      .map((field) => plain[field.key.toString()]);
+      .map((field) => {
+        const key = field.key.toString();
+        return typeof this[key]?.toStringKey === "function" ? this[key]?.toStringKey() : plain[key];
+      });
 
     return ChainObject.getCompositeKeyFromParts(classIndexKey, keyParts);
   }

--- a/chain-api/src/types/RangedChainObject.ts
+++ b/chain-api/src/types/RangedChainObject.ts
@@ -75,7 +75,10 @@ export abstract class RangedChainObject {
     const plain = instanceToPlain(this);
     const keyParts = fields
       .sort((a, b) => a.position - b.position)
-      .map((field) => plain[field.key.toString()]);
+      .map((field) => {
+        const key = field.key.toString();
+        return typeof this[key]?.toStringKey === "function" ? this[key]?.toStringKey() : plain[key];
+      });
 
     return RangedChainObject.getRangedKeyFromParts(classIndexKey, keyParts);
   }


### PR DESCRIPTION
In some cases we want to add custom serialization to chain object key part by using custom `.toStringKey()` method. For some reason we had regression with not considering it in our code. This is a fix.