### PR TITLE
Update docs order

### DIFF
--- a/.github/workflows/publish-page.yml
+++ b/.github/workflows/publish-page.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install mermaid-cli
         run: npm install -g @mermaid-js/mermaid-cli
       - name: Install pip packages
-        run: pip3 install mkdocs==1.5.3 mkdocs-material==9.4.8 mike==1.1.2 beautifulsoup4==4.9.3 setuptools==58.2.0
+        run: pip3 install mkdocs==1.5.3 mkdocs-material==9.4.8 mike==1.1.2 beautifulsoup4==4.9.3 setuptools==58.2.0 mkdocs-awesome-pages-plugin==2.9.2
       - name: Git config
         run: |
           git config --global user.email "${GITHUB_ACTOR}"

--- a/docs/.pages
+++ b/docs/.pages
@@ -1,0 +1,10 @@
+nav:
+    - Home: index.md
+    - GalaChain: galachain.md
+    - Getting Started: getting-started.md
+    - Galachain Development: chaincode-development.md
+    - Galachain Client: chaincode-client.md
+    - Galachain Testing: chaincode-testing.md
+    - Chaincode Deployment: chaincode-deployment.md
+    - Chaincode Post Deployment: chaincode-post-deployment.md
+    - ...

--- a/docs/chaincode-post-deployment.md
+++ b/docs/chaincode-post-deployment.md
@@ -1,4 +1,4 @@
-Assuming a brand new channel in the environment
+Assuming a brand new channel is deployed after following the steps in [chaincode-deployment.md](./chaincode-deployment.md).
 
 ## How to create keys
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,11 +16,16 @@ Read more about [GalaChain](galachain.md).
 
 - [**Getting started guide**](getting-started.md)
 - [Chaincode development](chaincode-development.md)
-- [CLI reference](../chain-cli/README.md)
+- [Chaincode client](chaincode-client.md)
+- [Chaincode testing](chaincode-testing.md)
 
 ## Deploying chaincode to GalaChain
 
 - [Chaincode deployment](chaincode-deployment.md)
+
+## Post Galachain deployment
+
+- [Chaincode post deployment](chaincode-post-deployment.md)
 
 ## Reference documentation
 - [`chain-api`](chain-api-docs/exports.md) - Common types, DTOs (Data Transfer Objects), APIs, signatures, and utils for GalaChain

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,8 @@ theme:
   logo: assets/white.png
   favicon: assets/favicon.png
   features:
+    - navigation.instant
+    - navigation.instant.progress
     - navigation.footer
     - toc.integrate
     - navigation.top
@@ -48,6 +50,7 @@ extra:
 plugins:
   - search
   - mike
+  - awesome-pages
   - with-pdf:
       exclude_pages:
         - "chain-api-docs/"


### PR DESCRIPTION
This PR adds a new mkdocs feature to customize the doc pages order.

It also:
- updates the CI job to install the package.
- updates `chaincode-first-steps.md` to `chaincode-post-deployment.md`

It'll make the order of the pages more intuitive and also will create a flow with the "Next" button in the bottom right of the page.
![Screenshot from 2024-02-12 18-56-27](https://github.com/GalaChain/sdk/assets/3007452/ebd06ae8-d76c-473e-8163-b37561c7c179)