### PR TITLE
Remove param muteQueryLimitError and fix all the calls

### DIFF
--- a/chaincode/src/__test__/TestGalaContract.ts
+++ b/chaincode/src/__test__/TestGalaContract.ts
@@ -126,6 +126,6 @@ export default class TestGalaContract extends GalaContract {
       })
     );
 
-    return getObjectsByPartialCompositeKey(ctx, Superhero.INDEX_KEY, [], Superhero, false);
+    return getObjectsByPartialCompositeKey(ctx, Superhero.INDEX_KEY, [], Superhero);
   }
 }

--- a/chaincode/src/allowances/fetchAllowances.ts
+++ b/chaincode/src/allowances/fetchAllowances.ts
@@ -49,8 +49,7 @@ export async function fetchAllowances(
     ctx,
     TokenAllowance.INDEX_KEY,
     queryParams,
-    TokenAllowance,
-    true // TODO: may lead to incomplete results
+    TokenAllowance
   );
 
   const results = filterByGrantedBy(getObjectsResponse, data.grantedBy);

--- a/chaincode/src/allowances/fullAllowanceCheck.ts
+++ b/chaincode/src/allowances/fullAllowanceCheck.ts
@@ -45,8 +45,7 @@ export async function fullAllowanceCheck(
     ctx,
     TokenBalance.INDEX_KEY,
     queryParams,
-    TokenBalance,
-    true // TODO: may lead to incomplete results
+    TokenBalance
   );
 
   // For each relevant balance, fetch relevant allowance(s)
@@ -69,8 +68,7 @@ export async function fullAllowanceCheck(
         ctx,
         TokenAllowance.INDEX_KEY,
         allowanceParams,
-        TokenAllowance,
-        true // TODO: may lead to incomplete results
+        TokenAllowance
       );
 
       const expiredAllowances = allowanceResults.filter((allowance) => {

--- a/chaincode/src/allowances/grantAllowance.ts
+++ b/chaincode/src/allowances/grantAllowance.ts
@@ -99,8 +99,7 @@ async function grantAllowanceByPartialKey(
             ctx,
             TokenAllowance.INDEX_KEY,
             allowanceQueryParamsForBalance,
-            TokenAllowance,
-            true // TODO: may lead to incomplete results
+            TokenAllowance
           )
         );
       }
@@ -122,8 +121,7 @@ async function grantAllowanceByPartialKey(
           ctx,
           TokenAllowance.INDEX_KEY,
           allowanceQueryParamsForBalance,
-          TokenAllowance,
-          true // TODO: may lead to incomplete results
+          TokenAllowance
         )
       );
     }
@@ -573,8 +571,7 @@ export async function preventDuplicateAllowance(
     ctx,
     TokenAllowance.INDEX_KEY,
     chainKeys,
-    TokenAllowance,
-    true // TODO: may lead to incomplete results
+    TokenAllowance
   );
 
   for (const existingAllowance of results) {

--- a/chaincode/src/balances/fetchBalances.ts
+++ b/chaincode/src/balances/fetchBalances.ts
@@ -43,8 +43,7 @@ export async function fetchBalances(
     ctx,
     TokenBalance.INDEX_KEY,
     queryParams,
-    TokenBalance,
-    true // TODO: may lead to incomplete results
+    TokenBalance
   ).catch((e) => {
     throw ChainError.map(e, ErrorCode.NOT_FOUND, new BalanceNotFoundError(ctx.callingUser));
   });

--- a/chaincode/src/burns/fetchBurns.ts
+++ b/chaincode/src/burns/fetchBurns.ts
@@ -47,13 +47,7 @@ export async function fetchBurns(ctx: GalaChainContext, data: FetchBurnParams): 
     data.created?.toString()
   );
 
-  let results = await getObjectsByPartialCompositeKey(
-    ctx,
-    TokenBurn.INDEX_KEY,
-    queryParams,
-    TokenBurn,
-    false
-  );
+  let results = await getObjectsByPartialCompositeKey(ctx, TokenBurn.INDEX_KEY, queryParams, TokenBurn);
 
   // Sort the items ascending by date
   results = results.sort((a: TokenBurn, b: TokenBurn): number => (a.created < b.created ? -1 : 1));

--- a/chaincode/src/mint/validateMintRequest.ts
+++ b/chaincode/src/mint/validateMintRequest.ts
@@ -84,8 +84,7 @@ export async function validateMintRequest(
       ctx,
       TokenAllowance.INDEX_KEY,
       queryParams,
-      TokenAllowance,
-      true // TODO may lead to incomplete results!
+      TokenAllowance
     );
 
     results.sort((a: TokenAllowance, b: TokenAllowance): number => (a.created < b.created ? -1 : 1));

--- a/chaincode/src/utils/state.ts
+++ b/chaincode/src/utils/state.ts
@@ -66,8 +66,7 @@ export async function getObjectsByPartialCompositeKey<T extends ChainObject>(
   ctx: GalaChainContext,
   objectType: string,
   attributes: string[],
-  constructor: ClassConstructor<Inferred<T, ChainObject>>,
-  muteQueryLimitError: boolean
+  constructor: ClassConstructor<Inferred<T, ChainObject>>
 ): Promise<Array<T>> {
   const iterator = ctx.stub.getCachedStateByPartialCompositeKey(objectType, attributes);
 
@@ -84,12 +83,7 @@ export async function getObjectsByPartialCompositeKey<T extends ChainObject>(
       `It means your results would be probably incomplete. ` +
       `Please narrow your query or use pagination.`;
 
-    if (muteQueryLimitError) {
-      ctx.logger.warn(message);
-    } else {
-      // why it is "forbidden" type of error: https://stackoverflow.com/a/15192643
-      throw new ForbiddenError(message, { objectType, attributes });
-    }
+    throw new ForbiddenError(message, { objectType, attributes });
   }
 
   // iterator will be automatically closed on exit from the loop


### PR DESCRIPTION
This PR removes the `muteQueryLimitError` from `getObjectsByPartialCompositeKey` to avoid returning incomplete results.