### PR TITLE
Remove name param from releaseToken

### DIFF
--- a/chain-api/src/types/TokenBalance.ts
+++ b/chain-api/src/types/TokenBalance.ts
@@ -315,11 +315,10 @@ export class TokenBalance extends ChainObject {
 
   public findInUseHold(
     instanceId: BigNumber,
-    name: string | undefined,
     currentTime: number
   ): TokenHold | undefined {
     this.ensureInstanceIsNft(instanceId);
-    return this.getUnexpiredInUseHolds(currentTime).find((h) => h.matches(instanceId, name));
+    return this.getUnexpiredInUseHolds(currentTime).find((h) => h.instanceId.isEqualTo(instanceId));
   }
 
   public containsAnyNftInstanceId(): boolean {

--- a/chaincode/src/__test__/GalaChainTokenContract.ts
+++ b/chaincode/src/__test__/GalaChainTokenContract.ts
@@ -393,8 +393,7 @@ export default class GalaChainTokenContract extends GalaContract {
   })
   public ReleaseToken(ctx: GalaChainContext, dto: ReleaseTokenDto): Promise<TokenBalance> {
     return releaseToken(ctx, {
-      tokenInstanceKey: dto.tokenInstance,
-      name: undefined
+      tokenInstanceKey: dto.tokenInstance
     });
   }
 

--- a/chaincode/src/use/releaseToken.ts
+++ b/chaincode/src/use/releaseToken.ts
@@ -23,12 +23,11 @@ import { ReleaseForbiddenUserError } from "./UseError";
 
 interface ReleaseTokenParams {
   tokenInstanceKey: TokenInstanceKey;
-  name: string | undefined;
 }
 
 export async function releaseToken(
   ctx: GalaChainContext,
-  { tokenInstanceKey, name }: ReleaseTokenParams
+  { tokenInstanceKey }: ReleaseTokenParams
 ): Promise<TokenBalance> {
   if (tokenInstanceKey.isFungible()) {
     throw new NotImplementedError("RealeaseToken is not supported for fungible tokens", {
@@ -41,7 +40,7 @@ export async function releaseToken(
   const owner = tokenInstance.owner as string;
 
   const balance = await fetchOrCreateBalance(ctx, owner, tokenInstanceKey.getTokenClassKey());
-  const applicableHold = balance.findInUseHold(tokenInstanceKey.instance, name, ctx.txUnixTime);
+  const applicableHold = balance.findInUseHold(tokenInstanceKey.instance, ctx.txUnixTime);
 
   // determine if user is authorized to release
   const authorized = applicableHold?.createdBy === ctx.callingUser || balance.owner === ctx.callingUser;


### PR DESCRIPTION
This PR removes `name` param from `releaseToken` to avoid leading to inconsistent state.

Closes https://github.com/GalaChain/sdk/issues/33