### PR TITLE
Fix comment typo

### DIFF
--- a/chaincode/src/burns/fetchBurns.ts
+++ b/chaincode/src/burns/fetchBurns.ts
@@ -115,7 +115,7 @@ export async function fetchKnownBurnCount(
 
         // inverted timeKeys read most recent first; using unshift sorts a new array as oldest first.
         // essentially, we rewind the tape and then play it forward.
-        // covering the following possible scensarios:
+        // covering the following possible scenarios:
         //     a) no results yet - empty array, start with zero below.
         //     b) no recent results. continue back toward the beginning of the ledger until we find at least one.
         //     c) recent results. Get all results within two past block spans to cover any missing timestamp gaps from concurrent recent transactions.

--- a/chaincode/src/mint/fetchMintAllowanceSupply.ts
+++ b/chaincode/src/mint/fetchMintAllowanceSupply.ts
@@ -85,7 +85,7 @@ export async function fetchMintAllowanceSupply(
 
         // inverted timeKeys read most recent first; using unshift sorts a new array as oldest first.
         // essentially, we rewind the tape and then play it forward.
-        // covering the following possible scensarios:
+        // covering the following possible scenarios:
         //     a) no results yet - empty array, start with zero below.
         //     b) no recent results. continue back toward the beginning of the ledger until we find at least one.
         //     c) recent results. Get all results within two past block spans to cover any missing timestamp gaps from concurrent recent transactions.


### PR DESCRIPTION
This Pr fixes the comment typo `scensarios` to `scenarios` in `fetchBurns` and `fetchMintAllowanceSupply`.

Closes https://github.com/GalaChain/sdk/issues/159