### PR TITLE
Add input validation for MintRequestDto

### DIFF
--- a/chain-api/src/types/TokenMintRequest.ts
+++ b/chain-api/src/types/TokenMintRequest.ts
@@ -82,6 +82,15 @@ export class TokenMintRequest extends RangedChainObject {
   @IsNotEmpty()
   public allowanceKey?: AllowanceKey;
 
+  public isTimeKeyValid(): boolean {
+    try {
+      new BigNumber(this.timeKey);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
   public requestId(): string {
     const { collection, category, type, additionalKey, totalKnownMintsCount, requestor, owner, created } =
       this;

--- a/chain-api/src/types/common.ts
+++ b/chain-api/src/types/common.ts
@@ -117,7 +117,7 @@ export class MintRequestDto {
   @IsNotEmpty()
   public allowanceKey?: AllowanceKey;
 
-  isTimeKeyValid(): boolean {
+  public isTimeKeyValid(): boolean {
     try {
       new BigNumber(this.timeKey);
       return true;

--- a/chain-api/src/types/common.ts
+++ b/chain-api/src/types/common.ts
@@ -116,4 +116,13 @@ export class MintRequestDto {
   @Type(() => AllowanceKey)
   @IsNotEmpty()
   public allowanceKey?: AllowanceKey;
+
+  isTimeKeyValid(): boolean {
+    try {
+      new BigNumber(this.timeKey);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
 }

--- a/chaincode/src/mint/fulfillMintAllowance.ts
+++ b/chaincode/src/mint/fulfillMintAllowance.ts
@@ -54,7 +54,7 @@ export async function fulfillMintAllowanceRequest(
   // todo: type this failures array and work it into response
   const failures: any[] = [];
 
-  for (const [key, values] of Object.entries(reqIdx)) {
+  for (const [_, values] of Object.entries(reqIdx)) {
     // Entries in the Request Index represent
     // some number of mint requests for the same token, at the same running total height.
     // Because our original GrantAllowance implementation allowed (potentially large) arrays,
@@ -84,6 +84,18 @@ export async function fulfillMintAllowanceRequest(
 
     for (const req of values) {
       // timeKeys are inverted timestamps, lowest = most recent, highest = oldest
+      if (req.isTimeKeyValid() === false) {
+        throw new Error(
+          `FulfillMintAllowance failure: Invalid timeKey value: ${
+            req.timeKey
+          }. The value of timeKey should be a valid BigNumber, ${inspect(req, {
+            depth: 4,
+            breakLength: Infinity,
+            compact: true
+          })}`
+        );
+      }
+
       const reqTime = new BigNumber(req.timeKey);
       if (reqTime.isLessThan(mostRecentTimeInversion)) {
         mostRecentTimeInversion = reqTime;


### PR DESCRIPTION
This PR adds a new input validation for `MintRequestDto` to check if the value of `timeKey` can be converted to a BigNumber.

Closes https://github.com/GalaChain/sdk/issues/155