### PR TITLE
Add grantedBy as a filter when fetching allowances in burnTokens

### DIFF
--- a/chain-test/src/data/currency.ts
+++ b/chain-test/src/data/currency.ts
@@ -84,6 +84,20 @@ const tokenBurnAllowancePlain = (txUnixTime: number) => ({
   usesSpent: new BigNumber(0)
 });
 
+const tokenBurnAllowanceUser3Plain = (txUnixTime: number) => ({
+  ...tokenClassKeyPlain(),
+  allowanceType: 6,
+  quantity: new BigNumber(1),
+  quantitySpent: new BigNumber(0),
+  created: txUnixTime,
+  expires: 0,
+  instance: new BigNumber(0),
+  grantedBy: users.testUser3Id,
+  grantedTo: users.testUser2Id,
+  uses: new BigNumber(1),
+  usesSpent: new BigNumber(0)
+});
+
 const tokenMintAllowancePlain = (txUnixTime: number) => ({
   ...tokenClassKeyPlain(),
   allowanceType: 4,
@@ -145,6 +159,8 @@ export default {
   tokenAllowance: createInstanceFn(TokenAllowance, tokenAllowancePlain(1)),
   tokenBurnAllowancePlain,
   tokenBurnAllowance: createInstanceFn(TokenAllowance, tokenBurnAllowancePlain(1)),
+  tokenBurnAllowanceUser3Plain,
+  tokenBurnAllowanceUser3: createInstanceFn(TokenAllowance, tokenBurnAllowanceUser3Plain(1)),
   tokenMintAllowancePlain,
   tokenMintAllowance: createInstanceFn(TokenAllowance, tokenMintAllowancePlain(1)),
   tokenInstanceKeyPlain,

--- a/chain-test/src/data/users.ts
+++ b/chain-test/src/data/users.ts
@@ -17,6 +17,7 @@ export default {
   testAdminId: "client|admin",
   testUser1Id: "client|testUser1",
   testUser2Id: "client|testUser2",
+  testUser3Id: "client|testUser3",
   tokenHolder: "client|tokenHolder",
   attacker: "client|maliciousUser"
 };

--- a/chaincode/src/burns/burnTokens.spec.ts
+++ b/chaincode/src/burns/burnTokens.spec.ts
@@ -101,7 +101,74 @@ describe("BurnTokens", () => {
     expect(writes).toEqual({});
   });
 
-  test("burns currency with allowance", async () => {
+  test("burns currency with burn allowance", async () => {
+    // Given
+    const currencyInstance = currency.tokenInstance();
+    const currencyInstanceKey = currency.tokenInstanceKey();
+    const currencyClass = currency.tokenClass();
+    const tokenBalance = currency.tokenBalance();
+    const burnQty = new BigNumber("1");
+    const tokenBurnAllowance = currency.tokenBurnAllowance();
+
+    const { ctx, contract, writes } = fixture(GalaChainTokenContract)
+      .callingUser(users.testUser2Id)
+      .savedState(currencyClass, currencyInstance, tokenBurnAllowance, tokenBalance)
+      .savedRangeState([]);
+
+    const dto = await createValidDTO(BurnTokensDto, {
+      tokenInstances: [{ tokenInstanceKey: currencyInstanceKey, quantity: burnQty }],
+      owner: users.testUser1Id
+    });
+
+    const tokenBurn = currency.tokenBurn();
+    tokenBurn.created = ctx.txUnixTime;
+    const tokenBurnCounter = plainToInstance(
+      TokenBurnCounter,
+      currency.tokenBurnCounterPlain(
+        ctx.txUnixTime,
+        inverseTime(ctx, 0),
+        inverseEpoch(ctx, 0),
+        new BigNumber("0")
+      )
+    );
+    tokenBurnCounter.referenceId = tokenBurnCounter.referencedBurnId();
+
+    const tokenClaim = plainToInstance(TokenClaim, {
+      ...currencyInstanceKey,
+      ownerKey: users.testUser2Id,
+      issuerKey: users.testUser1Id,
+      instance: new BigNumber("0"),
+      action: 6,
+      quantity: burnQty,
+      allowanceCreated: 1,
+      claimSequence: new BigNumber("1"),
+      created: ctx.txUnixTime
+    });
+
+    const expectedAllowance = plainToInstance(TokenAllowance, {
+      ...tokenBurnAllowance,
+      usesSpent: new BigNumber("1"),
+      quantitySpent: burnQty,
+      expires: ctx.txUnixTime
+    });
+
+    // When
+    const response = await contract.BurnTokens(ctx, dto);
+
+    // Then
+    expect(response).toEqual(GalaChainResponse.Success([tokenBurn]));
+    expect(writes).toEqual(
+      writesMap(
+        tokenClaim,
+        expectedAllowance,
+        plainToInstance(TokenBalance, { ...currency.tokenBalance(), quantity: new BigNumber("999") }),
+        tokenBurn,
+        tokenBurnCounter
+      )
+    );
+  });
+
+  test("burns currency with multiple allowance", async () => {
     // Given
     const currencyInstance = currency.tokenInstance();
     const currencyInstanceKey = currency.tokenInstanceKey();
@@ -167,6 +234,136 @@ describe("BurnTokens", () => {
         tokenBurnCounter
       )
     );
+  });
+
+  test("should filter allowances by brantedBy (owner)", async () => {
+    // Given
+    const currencyInstance = currency.tokenInstance();
+    const currencyInstanceKey = currency.tokenInstanceKey();
+    const currencyClass = currency.tokenClass();
+    const tokenBalance = currency.tokenBalance();
+    const burnQty = new BigNumber("1");
+    const tokenBurnAllowanceUser3 = currency.tokenBurnAllowanceUser3();
+    const tokenBurnAllowance = currency.tokenBurnAllowance();
+
+    const { ctx, contract, writes } = fixture(GalaChainTokenContract)
+      .callingUser(users.testUser2Id)
+      .savedState(currencyClass, currencyInstance, tokenBurnAllowanceUser3, tokenBurnAllowance, tokenBalance)
+      .savedRangeState([]);
+
+    const dto = await createValidDTO(BurnTokensDto, {
+      tokenInstances: [{ tokenInstanceKey: currencyInstanceKey, quantity: burnQty }],
+      owner: users.testUser1Id
+    });
+
+    const tokenBurn = currency.tokenBurn();
+    tokenBurn.created = ctx.txUnixTime;
+    const tokenBurnCounter = plainToInstance(
+      TokenBurnCounter,
+      currency.tokenBurnCounterPlain(
+        ctx.txUnixTime,
+        inverseTime(ctx, 0),
+        inverseEpoch(ctx, 0),
+        new BigNumber("0")
+      )
+    );
+    tokenBurnCounter.referenceId = tokenBurnCounter.referencedBurnId();
+
+    const tokenClaim = plainToInstance(TokenClaim, {
+      ...currencyInstanceKey,
+      ownerKey: users.testUser2Id,
+      issuerKey: users.testUser1Id,
+      instance: new BigNumber("0"),
+      action: 6,
+      quantity: burnQty,
+      allowanceCreated: 1,
+      claimSequence: new BigNumber("1"),
+      created: ctx.txUnixTime
+    });
+
+    const expectedAllowance = plainToInstance(TokenAllowance, {
+      ...tokenBurnAllowance,
+      usesSpent: new BigNumber("1"),
+      quantitySpent: burnQty,
+      expires: ctx.txUnixTime
+    });
+
+    // When
+    const response = await contract.BurnTokens(ctx, dto);
+
+    // Then
+    expect(response).toEqual(GalaChainResponse.Success([tokenBurn]));
+    expect(writes).toEqual(
+      writesMap(
+        tokenClaim,
+        expectedAllowance,
+        plainToInstance(TokenBalance, { ...currency.tokenBalance(), quantity: new BigNumber("999") }),
+        tokenBurn,
+        tokenBurnCounter
+      )
+    );
+  });
+
+  test("should fail to burn currency wrong allowance", async () => {
+    // Given
+    const currencyInstance = currency.tokenInstance();
+    const currencyInstanceKey = currency.tokenInstanceKey();
+    const currencyClass = currency.tokenClass();
+    const tokenBalance = currency.tokenBalance();
+    const burnQty = new BigNumber("1");
+    const tokenMintAllowance = currency.tokenMintAllowance();
+
+    const { ctx, contract, writes } = fixture(GalaChainTokenContract)
+      .callingUser(users.testUser2Id)
+      .savedState(currencyClass, currencyInstance, tokenMintAllowance, tokenBalance)
+      .savedRangeState([]);
+
+    const dto = await createValidDTO(BurnTokensDto, {
+      tokenInstances: [{ tokenInstanceKey: currencyInstanceKey, quantity: burnQty }],
+      owner: users.testUser1Id
+    });
+
+    const tokenBurn = currency.tokenBurn();
+    tokenBurn.created = ctx.txUnixTime;
+    const tokenBurnCounter = plainToInstance(
+      TokenBurnCounter,
+      currency.tokenBurnCounterPlain(
+        ctx.txUnixTime,
+        inverseTime(ctx, 0),
+        inverseEpoch(ctx, 0),
+        new BigNumber("0")
+      )
+    );
+    tokenBurnCounter.referenceId = tokenBurnCounter.referencedBurnId();
+
+    const tokenClaim = plainToInstance(TokenClaim, {
+      ...currencyInstanceKey,
+      ownerKey: users.testUser2Id,
+      issuerKey: users.testUser1Id,
+      instance: new BigNumber("0"),
+      action: 6,
+      quantity: burnQty,
+      allowanceCreated: 1,
+      claimSequence: new BigNumber("1"),
+      created: ctx.txUnixTime
+    });
+
+    // When
+    const response = await contract.BurnTokens(ctx, dto);
+
+    // Then
+    expect(response).toEqual(
+      GalaChainResponse.Error(
+        new InsufficientBurnAllowanceError(
+          users.testUser2Id,
+          new BigNumber("0"),
+          burnQty,
+          currencyInstanceKey,
+          users.testUser1Id
+        )
+      )
+    );
+    expect(writes).toEqual({});
   });
 
   test("fails to burn currency with no allowance", async () => {

--- a/chaincode/src/burns/burnTokens.spec.ts
+++ b/chaincode/src/burns/burnTokens.spec.ts
@@ -168,7 +168,7 @@ describe("BurnTokens", () => {
     );
   });
 
-  test("burns currency with multiple allowance", async () => {
+  test("burns currency with multiple allowances", async () => {
     // Given
     const currencyInstance = currency.tokenInstance();
     const currencyInstanceKey = currency.tokenInstanceKey();
@@ -236,7 +236,7 @@ describe("BurnTokens", () => {
     );
   });
 
-  test("should filter allowances by brantedBy (owner)", async () => {
+  test("should filter allowances by owner (grantedBy)", async () => {
     // Given
     const currencyInstance = currency.tokenInstance();
     const currencyInstanceKey = currency.tokenInstanceKey();
@@ -304,7 +304,7 @@ describe("BurnTokens", () => {
     );
   });
 
-  test("should fail to burn currency wrong allowance", async () => {
+  test("should fail to burn currency with wrong allowance", async () => {
     // Given
     const currencyInstance = currency.tokenInstance();
     const currencyInstanceKey = currency.tokenInstanceKey();
@@ -335,18 +335,6 @@ describe("BurnTokens", () => {
       )
     );
     tokenBurnCounter.referenceId = tokenBurnCounter.referencedBurnId();
-
-    const tokenClaim = plainToInstance(TokenClaim, {
-      ...currencyInstanceKey,
-      ownerKey: users.testUser2Id,
-      issuerKey: users.testUser1Id,
-      instance: new BigNumber("0"),
-      action: 6,
-      quantity: burnQty,
-      allowanceCreated: 1,
-      claimSequence: new BigNumber("1"),
-      created: ctx.txUnixTime
-    });
 
     // When
     const response = await contract.BurnTokens(ctx, dto);

--- a/chaincode/src/burns/burnTokens.ts
+++ b/chaincode/src/burns/burnTokens.ts
@@ -136,7 +136,8 @@ export async function burnTokens(
         type: tokenInstanceClassKey.type,
         additionalKey: tokenInstanceClassKey.additionalKey,
         instance: tokenInstance.instance.toString(),
-        allowanceType: AllowanceType.Burn
+        allowanceType: AllowanceType.Burn,
+        grantedBy: owner
       };
 
       applicableAllowanceResponse = await fetchAllowances(ctx, fetchAllowancesData);


### PR DESCRIPTION
This PR adds the `owner` param to `fetchAllowancesData` to be used as filter in `grantedBy`.

Closes https://github.com/GalaChain/sdk/issues/216