### PR TITLE
GalaChainClient updates

### DIFF
--- a/chain-connect/src/GalaChainClient.spec.ts
+++ b/chain-connect/src/GalaChainClient.spec.ts
@@ -288,6 +288,18 @@ describe("BrowserConnectClient", () => {
     client.disconnect();
     expect(client.walletAddress).toBe("");
   });
+
+  it("should attach listeners when connecting after disconnecting", async () => {
+    const client = new BrowserConnectClient();
+    const spy = jest.spyOn(client, "emit");
+    await client.connect();
+    client.disconnect();
+    await client.connect();
+    // Trigger the accountsChanged event
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window.ethereum as any).emit("accountsChanged", [sampleAddr]);
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("TrustConnectClient", () => {

--- a/chain-connect/src/GalaChainClient.ts
+++ b/chain-connect/src/GalaChainClient.ts
@@ -103,7 +103,7 @@ export abstract class WebSigner extends CustomClient {
   abstract connect(): Promise<string>;
 
   set walletAddress(val: string) {
-    this.address = getAddress(`0x${val.replace(/0x|eth\|/, "")}`);
+    this.address = val ? getAddress(`0x${val.replace(/0x|eth\|/, "")}`) : "";
   }
 
   get walletAddress(): string {

--- a/chain-connect/src/customClients/BrowserConnectClient.ts
+++ b/chain-connect/src/customClients/BrowserConnectClient.ts
@@ -85,6 +85,7 @@ export class BrowserConnectClient extends WebSigner {
   public disconnect() {
     if (this.isInitialized && window.ethereum) {
       window.ethereum.removeListener("accountsChanged", this.onAccountsChanged);
+      this.isInitialized = false;
     }
     this.walletAddress = "";
   }

--- a/chain-connect/src/customClients/BrowserConnectClient.ts
+++ b/chain-connect/src/customClients/BrowserConnectClient.ts
@@ -26,9 +26,12 @@ declare global {
 }
 
 export class BrowserConnectClient extends WebSigner {
+  protected isInitialized = false;
+
   constructor(provider?: Eip1193Provider) {
     super();
     this.address = "";
+    this.onAccountsChanged = this.onAccountsChanged.bind(this);
     if (provider) {
       this.provider = new BrowserProvider(provider);
     } else if (window.ethereum) {
@@ -45,23 +48,29 @@ export class BrowserConnectClient extends WebSigner {
     if (!window.ethereum) {
       return;
     }
-    window.ethereum.on("accountsChanged", (accounts: string[]) => {
-      if (accounts.length > 0) {
-        this.walletAddress = getAddress(accounts[0]);
-        this.emit("accountChanged", this.galachainEthAlias);
-        this.emit("accountsChanged", accounts);
-      } else {
-        this.walletAddress = "";
-        this.emit("accountChanged", null);
-        this.emit("accountsChanged", null);
-      }
-    });
+    if (!this.isInitialized) {
+      window.ethereum.on("accountsChanged", this.onAccountsChanged);
+      this.isInitialized = true;
+    }
+  }
+
+  protected onAccountsChanged(accounts: string[]) {
+    if (accounts.length > 0) {
+      this.walletAddress = getAddress(accounts[0]);
+      this.emit("accountChanged", this.galachainEthAlias);
+      this.emit("accountsChanged", accounts);
+    } else {
+      this.walletAddress = "";
+      this.emit("accountChanged", null);
+      this.emit("accountsChanged", null);
+    }
   }
 
   public async connect() {
     if (!this.provider) {
       throw new Error("Ethereum provider not found");
     }
+
     this.initializeListeners();
 
     try {
@@ -71,6 +80,13 @@ export class BrowserConnectClient extends WebSigner {
     } catch (error: unknown) {
       throw new Error((error as Error).message);
     }
+  }
+
+  public disconnect() {
+    if (this.isInitialized && window.ethereum) {
+      window.ethereum.removeListener("accountsChanged", this.onAccountsChanged);
+    }
+    this.walletAddress = "";
   }
 
   public async sign<U extends ConstructorArgs<ChainCallDTO>>(

--- a/chain-connect/src/helpers.ts
+++ b/chain-connect/src/helpers.ts
@@ -31,7 +31,8 @@ export function calculatePersonalSignPrefix(payload: object): string {
 }
 
 export interface ExtendedEip1193Provider extends Eip1193Provider {
-  on(event: "accountsChanged", handler: (accounts: string[]) => void): void;
+  on(event: "accountsChanged", handler: Listener<string[]>): void;
+  removeListener(event: "accountsChanged", handler: Listener<string[]>): void;
   providers?: Array<any>;
   isTrust?: boolean;
 }


### PR DESCRIPTION
- only attach listeners once
- add disconnect method for removing listeners & resetting local state
- fix bug that was occurring when the address was updated to an empty string (was attempting to set it as `0x` which triggered a validation error)

