### PR TITLE
v1: configure additional mint fees for specific tokens

### DIFF
--- a/chain-api/src/types/TokenMintConfiguration.ts
+++ b/chain-api/src/types/TokenMintConfiguration.ts
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import BigNumber from "bignumber.js";
 import { Exclude, Type } from "class-transformer";
 import {
   IsBoolean,
@@ -26,7 +27,7 @@ import {
 } from "class-validator";
 
 import { ChainKey, ValidationFailedError } from "../utils";
-import { IsUserAlias } from "../validators";
+import { BigNumberIsPositive, BigNumberProperty, IsUserAlias } from "../validators";
 import { ChainObject } from "./ChainObject";
 
 /**
@@ -121,6 +122,33 @@ export class BurnToMintConfiguration extends ChainObject {
 /**
  * @description
  *
+ * Configure additional fees specific to the token being minted.
+ * These fees will be charged in addition to any base fee
+ * globally configured for mint-specific contract methods using the
+ * `MintToken` `feeCode`.
+ */
+export class MintFeeConfiguration extends ChainObject {
+  /**
+   * @description
+   *
+   * Specify a flat fee to charge in addition to standard or
+   * global usage-based fees configured for the `MintToken`
+   * feeCode. This amount will be added to other fees.
+   *
+   * @example
+   *
+   * If the `MintToken` `feeCode` specifies a rate of 1 $GALA, setting this property
+   * to 99 would incur a total fee of 100 $GALA.
+   */
+  @IsOptional()
+  @BigNumberProperty()
+  @BigNumberIsPositive()
+  flatFee: BigNumber;
+}
+
+/**
+ * @description
+ *
  * Configure mint configurations for specific token classes.
  * The chain key properties are expected to match a token
  * class.
@@ -199,6 +227,17 @@ export class TokenMintConfiguration extends ChainObject {
   @ValidateNested()
   @Type(() => PostMintLockConfiguration)
   public postMintLock?: PostMintLockConfiguration;
+
+  /**
+   * @description
+   *
+   * (optional) configure how GalaChain Fees (paid in $GALA) are handled
+   * when minting the configured TokenClass.
+   */
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => MintFeeConfiguration)
+  public additionalFee?: MintFeeConfiguration;
 
   @Exclude()
   public validatePostProcessingTotals() {

--- a/chaincode/src/fees/galaFeeGate.ts
+++ b/chaincode/src/fees/galaFeeGate.ts
@@ -32,6 +32,7 @@ import { payFeeImmediatelyFromBalance } from "./payFeeImmediatelyFromBalance";
 export interface GalaFeeGateParams {
   feeCode: string;
   activeUser?: string | undefined;
+  additionalFee?: BigNumber | undefined;
 }
 
 /**
@@ -125,14 +126,19 @@ export async function writeUsageAndCalculateFeeAmount(
     userFeeThresholdUses
   );
 
-  const currentCumulativeFees = userFeeThresholdUses.cumulativeFeeQuantity.plus(feeAmount);
+  const additionalFee: BigNumber = data.additionalFee ?? new BigNumber("0");
+  const usageFeePlusAnyAdditionalFees = feeAmount.plus(additionalFee);
+
+  const currentCumulativeFees = userFeeThresholdUses.cumulativeFeeQuantity.plus(
+    usageFeePlusAnyAdditionalFees
+  );
 
   userFeeThresholdUses.cumulativeUses = cumulativeUses;
   userFeeThresholdUses.cumulativeFeeQuantity = currentCumulativeFees;
 
   await putChainObject(ctx, userFeeThresholdUses);
 
-  return { feeAmount, feeCodeDefinitions, cumulativeUses };
+  return { feeAmount: usageFeePlusAnyAdditionalFees, feeCodeDefinitions, cumulativeUses };
 }
 
 export interface cumulativeUsesAndFeeAmount {

--- a/chaincode/src/mint/fetchMintConfiguration.ts
+++ b/chaincode/src/mint/fetchMintConfiguration.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Gala Games Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ChainError, ErrorCode, TokenMintConfiguration } from "@gala-chain/api";
+
+import { GalaChainContext } from "../types";
+import { getObjectByKey } from "../utils";
+
+export interface IFetchMintConfiguration {
+  collection: string;
+  category: string;
+  type: string;
+  additionalKey: string;
+}
+
+export async function fetchTokenMintConfiguration(ctx: GalaChainContext, data: IFetchMintConfiguration) {
+  const { collection, category, type, additionalKey } = data;
+
+  const mintConfiguration: TokenMintConfiguration | undefined = await getObjectByKey(
+    ctx,
+    TokenMintConfiguration,
+    TokenMintConfiguration.getCompositeKeyFromParts(TokenMintConfiguration.INDEX_KEY, [
+      collection,
+      category,
+      type,
+      additionalKey
+    ])
+  ).catch((e) => {
+    const chainError = ChainError.from(e);
+    if (chainError.matches(ErrorCode.NOT_FOUND)) {
+      return undefined;
+    } else {
+      throw chainError;
+    }
+  });
+
+  return mintConfiguration;
+}

--- a/chaincode/src/mint/index.ts
+++ b/chaincode/src/mint/index.ts
@@ -22,6 +22,7 @@ import {
 import { constructVerifiedMints } from "./constructVerifiedMints";
 import { deleteTokenMintConfiguration } from "./deleteTokenMintConfiguration";
 import { fetchMintAllowanceSupply, fetchMintAllowanceSupplyForToken } from "./fetchMintAllowanceSupply";
+import { fetchTokenMintConfiguration } from "./fetchMintConfiguration";
 import { fetchTokenMintConfigurations } from "./fetchMintConfigurations";
 import { fetchMintSupply } from "./fetchMintSupply";
 import { fetchTokenClassesWithSupply } from "./fetchTokenClassWithSupply";
@@ -57,6 +58,7 @@ export {
   saveTokenMintConfiguration,
   validateMintRequest,
   fetchMintAllowanceSupply,
+  fetchTokenMintConfiguration,
   fetchTokenMintConfigurations,
   fetchMintSupply,
   fetchMintAllowanceSupplyForToken,


### PR DESCRIPTION
v1

Extend TokenMintConfiguration to specify additional fees, charged in $GALA, in addition to globally-configured fee quantities for mint operations for specific token classes.