### PR TITLE
Fix CLI compatibility with Node.js 18 and add manual docs publish action (backport from v2)

### DIFF
--- a/.github/workflows/manual-docs-publish.yml
+++ b/.github/workflows/manual-docs-publish.yml
@@ -1,0 +1,66 @@
+name: Manual Docs Publishing
+on:
+  workflow_dispatch:
+    inputs:
+      target_version:
+        description: 'Tag to publish docs for (e.g., v1.2.3)'
+        required: true
+        type: string
+
+env:
+  PAGES_BRANCH: gh-pages
+  HTTPS_REMOTE: "https://${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}"
+
+jobs:
+  publish-pages:
+    name: Publish Pages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install project dependencies
+        run: npm install
+      - name: Generate typedocs
+        run: |
+          npm run typedoc-chain-api
+          npm run typedoc-chain-client
+          npm run typedoc-chaincode
+          npm run typedoc-chain-connect
+          npm run typedoc-chain-test
+          npm run replace-readme-docs
+      - name: Install google-chrome
+        run: |
+          wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+          sudo dpkg -i google-chrome*.deb
+      - name: Install python3 and pip
+        run: |
+          sudo apt-get install -y python3
+          sudo apt-get install -y python3-pip python3-pillow python3-cffi python3-brotli gcc musl-dev python3-dev
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install mermaid-cli
+        run: npm install -g @mermaid-js/mermaid-cli
+      - name: Install pip packages
+        run: pip3 install mkdocs==1.5.3 mkdocs-material==9.4.8 mike==1.1.2 beautifulsoup4==4.9.3 setuptools==58.2.0 mkdocs-awesome-pages-plugin==2.9.2
+      - name: Git config
+        run: |
+          git config --global user.email "${GITHUB_ACTOR}"
+          git config --global user.name "${GITHUB_ACTOR}@gala.games"
+      - name: Clone mkdocs-with-pdf fixed branch and install
+        run: |
+          git clone -b render-mermaid-png https://github.com/Fuerback/mkdocs-with-pdf.git
+          cd mkdocs-with-pdf
+          sudo python3 setup.py install
+          cd ..
+      - name: Mkdocs build
+        run: |
+          mkdocs build
+      - name: Push a new version of the docs
+        run: |
+          git stash
+          git fetch origin $PAGES_BRANCH && git -b checkout $PAGES_BRANCH origin/$PAGES_BRANCH || git checkout $PAGES_BRANCH || echo "Pages branch not deployed yet."
+          git checkout $GITHUB_SHA
+          mike deploy --rebase --prefix docs -r $HTTPS_REMOTE -p -b $PAGES_BRANCH -u ${{ inputs.target_version }} latest
+          mike set-default --rebase --prefix docs -r $HTTPS_REMOTE -p -b $PAGES_BRANCH latest
+          git checkout $PAGES_BRANCH -- docs/ 

--- a/.github/workflows/manual-version-bump.yml
+++ b/.github/workflows/manual-version-bump.yml
@@ -1,6 +1,11 @@
 name: SDK Version bump
 on:
   workflow_dispatch:
+    inputs:
+      target_branch:
+        description: 'Target branch (main or main-v*)'
+        required: true
+        default: 'main'
 jobs:
   bump-version:
     name: Bump SDK Version
@@ -9,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: "main"
+          ref: ${{ inputs.target_branch }}
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -27,7 +32,7 @@ jobs:
       - name: Create a new branch
         run: |
           BRANCH_NAME="bump-version-to-$VERSION"
-          git checkout -b $BRANCH_NAME main
+          git checkout -b $BRANCH_NAME ${{ inputs.target_branch }}
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
       - name: Bump version and commit changes
         run: |
@@ -38,4 +43,4 @@ jobs:
       - name: Create Pull Request
         env:
           GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
-        run: gh pr create --title "Bump Version to $VERSION" --body "Bump Version to $VERSION" --label "bump-version-pr" --head "bump-version-to-$VERSION" --base main
+        run: gh pr create --title "Bump Version to $VERSION" --body "Bump Version to $VERSION" --label "bump-version-pr" --head "bump-version-to-$VERSION" --base ${{ inputs.target_branch }}

--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Git config
         run: |
           git config --global user.email "${GITHUB_ACTOR}"
-          git config --global user.name "${GITHUB_ACTOR}@gala.games.com"
+          git config --global user.name "${GITHUB_ACTOR}@gala.games"
       - name: Clone mkdocs-with-pdf fixed branch and install
         run: |
           git clone -b render-mermaid-png https://github.com/Fuerback/mkdocs-with-pdf.git

--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -180,7 +180,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: "main"
+          ref: ${{ startsWith(github.ref_name, 'v1.') && 'main-v1' || 'main' }}
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -197,9 +197,11 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
       - name: Create a new branch
         run: |
+          TARGET_BRANCH="${{ startsWith(github.ref_name, 'v1.') && 'main-v1' || 'main' }}"
           BRANCH_NAME="bump-version-to-$VERSION"
-          git checkout -b $BRANCH_NAME main
+          git checkout -b $BRANCH_NAME $TARGET_BRANCH
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+          echo "TARGET_BRANCH=$TARGET_BRANCH" >> $GITHUB_ENV
       - name: Bump version and commit changes
         run: |
           ./unifyVersions.js $VERSION
@@ -209,7 +211,7 @@ jobs:
       - name: Create Pull Request
         env:
           GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
-        run: gh pr create --title "Bump Version to $VERSION" --body "Bump Version to $VERSION" --label "bump-version-pr" --head "bump-version-to-$VERSION" --base main
+        run: gh pr create --title "Bump Version to $VERSION" --body "Bump Version to $VERSION" --label "bump-version-pr" --head "bump-version-to-$VERSION" --base ${{ env.TARGET_BRANCH }}
 
   notify-tag:
     needs: [publish, publish-cli-image]

--- a/chain-cli/src/commands/logs/index.ts
+++ b/chain-cli/src/commands/logs/index.ts
@@ -213,13 +213,7 @@ export default class Log extends BaseCommand<typeof Log> {
     }
 
     const date = new Date(timestamp);
-    const formattedTime = date.toLocaleTimeString("en-US", {
-      hour12: false,
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-      fractionalSecondDigits: 3
-    });
+    const formattedTime = date.toISOString().slice(11, -1);
 
     this.log(`${chalk.gray(formattedTime)} ${levelColor(levelPadded)} ${message}`);
   }


### PR DESCRIPTION
This fix contains changes from https://github.com/GalaChain/sdk/pull/457