### PR TITLE
Have getPublicKey() return the correct result for private keys prefixed with 0x

### DIFF
--- a/chain-api/src/utils/signatures/eth.spec.ts
+++ b/chain-api/src/utils/signatures/eth.spec.ts
@@ -107,6 +107,16 @@ describe("public key", () => {
     // Then
     expect(normalizedKey).toEqual(normalized);
   });
+
+  it("should tolerate private key beginning with 0x", () => {
+    const keyWithPrefix = '0x0000000000000000000000000000000000000000000000000000000000000001';
+    const ketWithoutPrefix = keyWithPrefix.slice(2);
+
+    const publicKeyWithPrefix = signatures.getPublicKey(keyWithPrefix);
+    const publicKeyWithoutPrefix = signatures.getPublicKey(ketWithoutPrefix);
+
+    expect(publicKeyWithPrefix).toEqual(publicKeyWithoutPrefix);
+  });
 });
 
 describe("signatures", () => {

--- a/chain-api/src/utils/signatures/eth.spec.ts
+++ b/chain-api/src/utils/signatures/eth.spec.ts
@@ -109,7 +109,7 @@ describe("public key", () => {
   });
 
   it("should tolerate private key beginning with 0x", () => {
-    const keyWithPrefix = '0x0000000000000000000000000000000000000000000000000000000000000001';
+    const keyWithPrefix = "0x0000000000000000000000000000000000000000000000000000000000000001";
     const ketWithoutPrefix = keyWithPrefix.slice(2);
 
     const publicKeyWithPrefix = signatures.getPublicKey(keyWithPrefix);

--- a/chain-api/src/utils/signatures/eth.ts
+++ b/chain-api/src/utils/signatures/eth.ts
@@ -122,7 +122,7 @@ function getNonCompactHexPublicKey(publicKey: string): string {
 const ecSecp256k1 = new EC("secp256k1");
 
 function getPublicKey(privateKey: string): string {
-  const pkObj = new EC("secp256k1").keyFromPrivate(privateKey, "hex");
+  const pkObj = new EC("secp256k1").keyFromPrivate(privateKey.replace(/^0x/, ''), "hex");
   return pkObj.getPublic().encode("hex", false).toString();
 }
 

--- a/chain-api/src/utils/signatures/eth.ts
+++ b/chain-api/src/utils/signatures/eth.ts
@@ -122,7 +122,7 @@ function getNonCompactHexPublicKey(publicKey: string): string {
 const ecSecp256k1 = new EC("secp256k1");
 
 function getPublicKey(privateKey: string): string {
-  const pkObj = new EC("secp256k1").keyFromPrivate(privateKey.replace(/^0x/, ''), "hex");
+  const pkObj = new EC("secp256k1").keyFromPrivate(privateKey.replace(/^0x/, ""), "hex");
   return pkObj.getPublic().encode("hex", false).toString();
 }
 


### PR DESCRIPTION
This aligns with how `Wallet` in `ethers` handles private keys:

```js
const ethers = require('ethers');

const walletWithoutPrefix = new ethers.Wallet(
  '0000000000000000000000000000000000000000000000000000000000000001'
);
const walletWithPrefix = new ethers.Wallet(
  '0x0000000000000000000000000000000000000000000000000000000000000001'
);

console.log(walletWithPrefix.publicKey === walletWithoutPrefix.publicKey);
// true
```