### PR TITLE
Update publish workflow to support version-specific npm dist tags

### DIFF
--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -23,19 +23,28 @@ jobs:
           node-version: 18
       - name: Install Dependencies
         run: npm i
-      - name: Set up version
+      - name: Set up version and tag
         run: |
           # Extract package name and version
           NPM_PACKAGE_NAME=$(node -p "require('./package.json').name")
           NPM_PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          # Set NPM_DIST_TAG based on version
+          if [[ $NPM_PACKAGE_VERSION == 2.* ]]; then
+            echo "NPM_DIST_TAG=latest" >> $GITHUB_ENV
+          elif [[ $NPM_PACKAGE_VERSION == 1.* ]]; then
+            echo "NPM_DIST_TAG=v1-latest" >> $GITHUB_ENV
+          else
+            echo "Error: Version must start with 1.* or 2.*"
+            exit 1
+          fi
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NODE_AUTH_TOKEN }}" > .npmrc
       - name: publish-chain-api
         run: |
           cd chain-api
           npm i
           npm run build
-          # Publish to NPM registry
-          npm publish --access public
+          # Publish to NPM registry with appropriate tag
+          npm publish --access public --tag ${{ env.NPM_DIST_TAG }}
           cd ../
 
       - name: publish-chain-test

--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -52,7 +52,7 @@ jobs:
           cd chain-test
           npm i
           npm run build
-          npm publish --access public
+          npm publish --access public --tag ${{ env.NPM_DIST_TAG }}
           cd ../
 
       - name: publish-chain-cli
@@ -60,7 +60,7 @@ jobs:
           cd chain-cli
           npm i
           npm run build
-          npm publish --access public
+          npm publish --access public --tag ${{ env.NPM_DIST_TAG }}
           cd ../
 
       - name: publish-chaincode
@@ -68,7 +68,7 @@ jobs:
           cd chaincode
           npm i
           npm run build
-          npm publish --access public
+          npm publish --access public --tag ${{ env.NPM_DIST_TAG }}
           cd ../
 
       - name: publish-client
@@ -76,7 +76,7 @@ jobs:
           cd chain-client
           npm i
           npm run build
-          npm publish --access public
+          npm publish --access public --tag ${{ env.NPM_DIST_TAG }}
           cd ../
 
       - name: publish-chain-connect
@@ -85,7 +85,7 @@ jobs:
           npm i
           npm run build
           # Publish to NPM registry
-          npm publish --access public
+          npm publish --access public --tag ${{ env.NPM_DIST_TAG }}
           cd ../
 
   publish-pages:
@@ -108,10 +108,13 @@ jobs:
         run: |
           wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
           sudo dpkg -i google-chrome*.deb
-      - name: Install python3 and pip
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install system dependencies
         run: |
-          sudo apt-get install -y python3
-          sudo apt-get install -y python3-pip python3-pillow python3-cffi python3-brotli gcc musl-dev python3-dev
+          sudo apt-get install -y gcc musl-dev
       - name: Setup Node.js
         uses: actions/setup-node@v3
       - name: Install mermaid-cli
@@ -134,7 +137,7 @@ jobs:
       - name: Push a new version of the docs
         run: |
           git stash
-          git fetch origin $PAGES_BRANCH && git -b checkout $PAGES_BRANCH origin/$PAGES_BRANCH || git checkout $PAGES_BRANCH || echo "Pages branch not deployed yet."
+          git fetch origin $PAGES_BRANCH && git checkout -b $PAGES_BRANCH origin/$PAGES_BRANCH || git checkout $PAGES_BRANCH || echo "Pages branch not deployed yet."
           git checkout $GITHUB_SHA
           mike deploy --rebase --prefix docs -r $HTTPS_REMOTE -p -b $PAGES_BRANCH -u ${GITHUB_REF#refs/tags/} latest
           mike set-default --rebase --prefix docs -r $HTTPS_REMOTE -p -b $PAGES_BRANCH latest


### PR DESCRIPTION
closes https://github.com/GalaChain/sdk/issues/472

also applies changes from: https://github.com/GalaChain/sdk/pull/487 (Python version set to 3.11 to fix docs publishing)