### PR TITLE
Fix: Allow Ethereum user alias without 0x prefix only

### DIFF
--- a/chain-api/src/validators/IsUserAlias.spec.ts
+++ b/chain-api/src/validators/IsUserAlias.spec.ts
@@ -57,6 +57,7 @@ test.each<[string, string, string]>([
   ["invalid client alias (multiple |)", "client|123|45", "Expected string following the format"],
   ["invalid client alias (empty id)", "client|", "Expected string following the format"],
   ["invalid eth alias (lower-cased eth)", `eth|${lowerCasedEth}`, "'eth|' must end with valid checksumed"],
+  ["invalid eth alias (0x prefix)", `eth|0x${validEthAddress}`, "'eth|' must end with valid checksumed"],
   ["invalid eth alias (invalid eth)", "eth|123", "'eth|' must end with valid checksumed"],
   ["invalid value (pure eth addr)", validEthAddress, "Expected string following the format"],
   ["invalid ton alias (invalid checksum)", `ton|${invalidTon}`, "'ton|' must end with valid bounceable"],

--- a/chain-api/src/validators/IsUserAlias.ts
+++ b/chain-api/src/validators/IsUserAlias.ts
@@ -32,7 +32,7 @@ enum UserRefValidationResult {
 
 const customMessages = {
   [UserRefValidationResult.INVALID_ETH_USER_ALIAS]:
-    "User alias starting with 'eth|' must end with valid checksumed eth address.",
+    "User alias starting with 'eth|' must end with valid checksumed eth address without 0x prefix.",
   [UserRefValidationResult.INVALID_TON_USER_ALIAS]:
     "User alias starting with 'ton|' must end with valid bounceable base64 TON address."
 };
@@ -77,7 +77,7 @@ function validateUserAlias(value: unknown): UserRefValidationResult {
     }
 
     if (parts[0] === "eth") {
-      if (signatures.isChecksumedEthAddress(parts[1])) {
+      if (signatures.isChecksumedEthAddress(parts[1]) && !parts[1].startsWith("0x")) {
         return UserRefValidationResult.VALID_USER_ALIAS;
       } else {
         return UserRefValidationResult.INVALID_ETH_USER_ALIAS;


### PR DESCRIPTION
Enhance Ethereum user alias validation to reject addresses with '0x' prefix and update error message to clarify the expected format