### PR TITLE
Change pool address delimiter to dollar sign to handle underscore edge cases

### DIFF
--- a/chain-cli/chaincode-template/e2e/dex-api.spec.ts
+++ b/chain-cli/chaincode-template/e2e/dex-api.spec.ts
@@ -1358,7 +1358,7 @@ describe("DEx v3 Testing", () => {
         Data: expect.objectContaining({
           totalCount: 4,
           positions: expect.objectContaining({
-            "new-collection0$new-category0$new-type0$ETH_new-collection0$new-category0$new-type0$USDT_3000": [
+            "new-collection0$new-category0$new-type0$ETH$new-collection0$new-category0$new-type0$USDT$3000": [
               {
                 liquidity: "0.436872924385936373",
                 tickLower: 74400,
@@ -1406,7 +1406,7 @@ describe("DEx v3 Testing", () => {
                 token1Symbol: "USDT"
               }
             ],
-            "new-collection0$new-category0$new-type0$ETH_new-collection0$new-category0$new-type0$USDT_500": [
+            "new-collection0$new-category0$new-type0$ETH$new-collection0$new-category0$new-type0$USDT$500": [
               {
                 liquidity: "0.42495639238882534",
                 tickLower: 74390,

--- a/chain-cli/chaincode-template/e2e/dex-unit.spec.ts
+++ b/chain-cli/chaincode-template/e2e/dex-unit.spec.ts
@@ -247,8 +247,8 @@ describe("validateTokenOrder", () => {
   });
 });
 describe("genKey", () => {
-  test("should concatenate parameters with '_'", () => {
-    expect(genKey("1", "2", "3", "4")).toBe("1_2_3_4");
+  test("should concatenate parameters with '$'", () => {
+    expect(genKey("1", "2", "3", "4")).toBe("1$2$3$4");
   });
 });
 

--- a/chaincode/src/dex/getFunctions.ts
+++ b/chaincode/src/dex/getFunctions.ts
@@ -239,26 +239,25 @@ async function addMetaDataToPositions(
   positions: PositionsObject
 ): Promise<PositionsObject> {
   for (const [key, value] of Object.entries(positions)) {
-    const poolKeys = key.split("_");
+    const token0 = new TokenClassKey();
+    const token1 = new TokenClassKey();
+    let fee: string;
+    [
+      token0.collection,
+      token0.category,
+      token0.type,
+      token0.additionalKey,
+      token1.collection,
+      token1.category,
+      token1.type,
+      token1.additionalKey,
+      fee
+    ] = key
+      .replace(/\$\$/g, "$|")
+      .split("$")
+      .map((str) => str.replace(/\|/g, "$"));
 
-    const poolToken0ClassKey = new TokenClassKey();
-    const token0ClassKeyString = poolKeys[0].split("$");
-    poolToken0ClassKey.collection = token0ClassKeyString[0];
-    poolToken0ClassKey.category = token0ClassKeyString[1];
-    poolToken0ClassKey.type = token0ClassKeyString[2];
-    poolToken0ClassKey.additionalKey = token0ClassKeyString[3];
-
-    const poolToken1ClassKey = new TokenClassKey();
-    const token1ClassKeyString = poolKeys[1].split("$");
-    poolToken1ClassKey.collection = token1ClassKeyString[0];
-    poolToken1ClassKey.category = token1ClassKeyString[1];
-    poolToken1ClassKey.type = token1ClassKeyString[2];
-    poolToken1ClassKey.additionalKey = token1ClassKeyString[3];
-
-    const pool = await getPoolData(
-      ctx,
-      new GetPoolDto(poolToken0ClassKey, poolToken1ClassKey, Number(poolKeys[2]))
-    );
+    const pool = await getPoolData(ctx, new GetPoolDto(token0, token1, parseInt(fee)));
     if (!pool) {
       continue;
     }

--- a/chaincode/src/utils/dexUtils.ts
+++ b/chaincode/src/utils/dexUtils.ts
@@ -89,7 +89,7 @@ export function validateTokenOrder(token0: TokenClassKey, token1: TokenClassKey)
 }
 
 export function genKey(...params: string[] | number[]): string {
-  return params.join("_").replace(/\|/g, ":");
+  return params.join("$").replace(/\|/g, ":");
 }
 
 export function genKeyWithPipe(...params: string[] | number[]): string {


### PR DESCRIPTION
Change pool address delimiter to dollar sign so that underscore can be used in token compound keys without causing any issue with pool functionality 