### PR TITLE
fix: BatchSubmit does not preserve writes from failed transactions

### DIFF
--- a/chaincode/src/contracts/GalaContract.spec.ts
+++ b/chaincode/src/contracts/GalaContract.spec.ts
@@ -378,7 +378,11 @@ describe("GalaContract.DryRun", () => {
       ErrorCode: 404,
       ErrorKey: "NOT_FOUND",
       Message:
-        "Method UnknownMethod is not available. Available methods: BatchEvaluate, BatchSubmit, CreateSuperhero, DryRun, ErrorAfterPutKv, GetChaincodeVersion, GetContractAPI, GetContractVersion, GetKv, GetObjectByKey, GetObjectHistory, PutKv, QuerySuperheroes"
+        "Method UnknownMethod is not available. Available methods: " +
+        "BatchEvaluate, BatchSubmit, CreateSuperhero, DryRun, ErrorAfterPutKv, " +
+        "ErrorAfterPutNestedKv, GetChaincodeVersion, GetContractAPI, GetContractVersion, " +
+        "GetKv, GetNestedKv, GetObjectByKey, GetObjectHistory, " +
+        "GetSetPutNestedKv, PutKv, PutNestedKv, QuerySuperheroes"
     });
   });
 
@@ -492,6 +496,48 @@ describe("GalaContract.Batch", () => {
         transactionSuccess(),
         transactionSuccess(),
         transactionErrorKey("BATCH_WRITE_LIMIT_EXCEEDED")
+      ])
+    );
+  });
+
+  it("should reset writes occurring during failed transactions", async () => {
+    // Given
+    const chaincode = new TestChaincode([TestGalaContract]);
+    const batchSubmit1 = plainToInstance(BatchDto, {
+      operations: [
+        { method: "PutNestedKv", dto: { key: "test-key-1", array: ["robot"] } },
+        { method: "ErrorAfterPutNestedKv", dto: { key: "test-key-1", array: ["robot", "zerg"] } },
+        { method: "GetSetPutNestedKv", dto: { key: "test-key-1", array: ["human"] } }
+      ],
+      writesLimit: 1000
+    });
+
+    const batchSubmit2 = plainToInstance(BatchDto, {
+      operations: [
+        { method: "PutNestedKv", dto: { key: "test-key-2", array: ["robot"] } },
+        { method: "GetSetPutNestedKv", dto: { key: "test-key-2", array: ["zerg"] } },
+        { method: "GetSetPutNestedKv", dto: { key: "test-key-2", array: ["human"] } }
+      ],
+      writesLimit: 1000
+    });
+
+    // When
+    const response1 = await chaincode.invoke("TestGalaContract:BatchSubmit", batchSubmit1.serialize());
+    const response2 = await chaincode.invoke("TestGalaContract:BatchSubmit", batchSubmit2.serialize());
+
+    // Then
+    expect(response1).toEqual(
+      transactionSuccess([
+        transactionSuccess(),
+        transactionErrorMessageContains("Some error after put was invoked"),
+        transactionSuccess({ key: "test-key-1", array: ["robot", "human"] })
+      ])
+    );
+    expect(response2).toEqual(
+      transactionSuccess([
+        transactionSuccess(),
+        transactionSuccess({ key: "test-key-2", array: ["robot", "zerg"] }),
+        transactionSuccess({ key: "test-key-2", array: ["robot", "zerg", "human"] })
       ])
     );
   });

--- a/chaincode/src/contracts/GalaContract.ts
+++ b/chaincode/src/contracts/GalaContract.ts
@@ -201,7 +201,7 @@ export abstract class GalaContract extends Contract {
       batchDto.writesLimit ?? BatchDto.WRITES_DEFAULT_LIMIT,
       BatchDto.WRITES_HARD_LIMIT
     );
-    let writesCount = Object.keys(ctx.stub.getWrites()).length;
+    let writesCount = Object.keys(aggregatedCache.writes).length;
 
     for (const op of batchDto.operations) {
       // 1. Reset the calling user, to allow each operation to perform the

--- a/chaincode/src/types/GalaChainStub.ts
+++ b/chaincode/src/types/GalaChainStub.ts
@@ -135,11 +135,23 @@ class StubCache {
   }
 
   getReads(): Record<string, Uint8Array> {
-    return { ...this.reads };
+    const reads = {};
+
+    for (const [key, value] of Object.entries(this.reads)) {
+      reads[key] = Buffer.from(value.toString());
+    }
+
+    return reads;
   }
 
   getWrites(): Record<string, Uint8Array> {
-    return { ...this.writes };
+    const writes = {};
+
+    for (const [key, value] of Object.entries(this.writes)) {
+      writes[key] = Buffer.from(value.toString());
+    }
+
+    return writes;
   }
 
   getDeletes(): Record<string, true> {
@@ -147,15 +159,38 @@ class StubCache {
   }
 
   setReads(reads: Record<string, Uint8Array>): void {
-    this.reads = { ...reads };
+    for (const key of Object.keys(this.reads)) {
+      delete this.reads[key];
+    }
+
+    for (const key of Object.keys(reads)) {
+      this.reads[key] = reads[key];
+    }
   }
 
   setWrites(writes: Record<string, Uint8Array>): void {
-    this.writes = { ...writes };
+    // assignment on this private class property,
+    // e.g. this.writes = { ...writes },
+    // will silently fail.
+    for (const key of Object.keys(this.writes)) {
+      delete this.writes[key];
+    }
+
+    // deleting all prior keys, and then re-assigning all new key/values
+    // fully updates the existing object with the new object references.
+    for (const key of Object.keys(writes)) {
+      this.writes[key] = writes[key];
+    }
   }
 
   setDeletes(deletes: Record<string, true>): void {
-    this.deletes = { ...deletes };
+    for (const key of Object.keys(this.deletes)) {
+      delete this.deletes[key];
+    }
+
+    for (const key of Object.keys(deletes)) {
+      this.deletes[key] = deletes[key];
+    }
   }
 }
 


### PR DESCRIPTION
// Given
Batch Requests 1, 2, 3

// When
BatchRequest1:

read keyA
write keyA

successful

BatchRequest2:

write keyA <-- gets BatchRequest1's changes

error/failure

BatchRequest3:

read keyA <-- should NOT get BatchRequest2's changes

// Then
BatchRequest3 should not get BatchRequest2's changes
