### PR TITLE
Feat: Sandbox for BatchSubmit (port of #583 #587)

### DIFF
--- a/chain-test/src/unit/fixture.ts
+++ b/chain-test/src/unit/fixture.ts
@@ -54,11 +54,14 @@ interface GalaLoggerInstance {
 }
 
 type GalaChainStub = ChaincodeStub & {
+  getTxID(): string;
   getCachedState(key: string): Promise<Uint8Array>;
   getCachedStateByPartialCompositeKey(objectType: string, attributes: string[]): FabricIterable<CachedKV>;
   flushWrites(): Promise<void>;
   getReads(): Record<string, Uint8Array>;
   getWrites(): Record<string, Uint8Array>;
+  getWritesCount(): number;
+  getWritesCount(): number;
   getDeletes(): Record<string, true>;
   setReads(reads: Record<string, Uint8Array>): void;
   setWrites(writes: Record<string, Uint8Array>): void;
@@ -84,11 +87,20 @@ type TestGalaChainContext = Context & {
   get callingUser(): UserAlias;
   get callingUserEthAddress(): string;
   get callingUserTonAddress(): string;
+<<<<<<< HEAD
   get callingUserRoles(): string[];
   get callingUserProfile(): UserProfile;
   resetCallingUser(): void;
   get config(): GalaChainContextConfig;
   setDryRunOnBehalfOf(d: CallingUserData): void;
+=======
+  setDryRunOnBehalfOf(d: { alias: string; ethAddress: string | undefined }): void;
+<<<<<<< HEAD
+  createReadOnlyContext(): TestGalaChainContext;
+>>>>>>> cfe814e (Feat: Sandboxed stub in batch operations (#583))
+=======
+  createReadOnlyContext(index: number | undefined): TestGalaChainContext;
+>>>>>>> dd9c19d (Feat: Add txId index suffix for transactions in batch (#587))
   isDryRun: boolean;
   get txUnixTime(): number;
   setChaincodeStub(stub: ChaincodeStub): void;

--- a/chain-test/src/unit/fixture.ts
+++ b/chain-test/src/unit/fixture.ts
@@ -61,7 +61,6 @@ type GalaChainStub = ChaincodeStub & {
   getReads(): Record<string, Uint8Array>;
   getWrites(): Record<string, Uint8Array>;
   getWritesCount(): number;
-  getWritesCount(): number;
   getDeletes(): Record<string, true>;
   setReads(reads: Record<string, Uint8Array>): void;
   setWrites(writes: Record<string, Uint8Array>): void;

--- a/chain-test/src/unit/fixture.ts
+++ b/chain-test/src/unit/fixture.ts
@@ -86,20 +86,12 @@ type TestGalaChainContext = Context & {
   get callingUser(): UserAlias;
   get callingUserEthAddress(): string;
   get callingUserTonAddress(): string;
-<<<<<<< HEAD
   get callingUserRoles(): string[];
   get callingUserProfile(): UserProfile;
   resetCallingUser(): void;
   get config(): GalaChainContextConfig;
   setDryRunOnBehalfOf(d: CallingUserData): void;
-=======
-  setDryRunOnBehalfOf(d: { alias: string; ethAddress: string | undefined }): void;
-<<<<<<< HEAD
-  createReadOnlyContext(): TestGalaChainContext;
->>>>>>> cfe814e (Feat: Sandboxed stub in batch operations (#583))
-=======
   createReadOnlyContext(index: number | undefined): TestGalaChainContext;
->>>>>>> dd9c19d (Feat: Add txId index suffix for transactions in batch (#587))
   isDryRun: boolean;
   get txUnixTime(): number;
   setChaincodeStub(stub: ChaincodeStub): void;

--- a/chaincode/src/contracts/GalaContract.spec.ts
+++ b/chaincode/src/contracts/GalaContract.spec.ts
@@ -21,17 +21,13 @@ import {
   GalaChainResponse,
   GalaChainResponseType,
   GetObjectDto,
-<<<<<<< HEAD
-  createValidChainObject,
-  createValidDTO,
-  serialize
-=======
   PublicKey,
   SigningScheme,
   UserProfile,
+  createValidChainObject,
   createValidDTO,
+  serialize,
   signatures
->>>>>>> cfe814e (Feat: Sandboxed stub in batch operations (#583))
 } from "@gala-chain/api";
 import { ChainUser } from "@gala-chain/client";
 import {
@@ -46,15 +42,8 @@ import { Context } from "fabric-contract-api";
 import { inspect } from "util";
 
 import TestGalaContract, { Superhero, SuperheroDto, SuperheroQueryDto } from "../__test__/TestGalaContract";
-<<<<<<< HEAD
-import { GalaChainContext } from "../types";
-=======
 import { GalaChainContext, createValidChainObject } from "../types";
-<<<<<<< HEAD
 import { PublicKeyContract } from "./PublicKeyContract";
->>>>>>> cfe814e (Feat: Sandboxed stub in batch operations (#583))
-=======
->>>>>>> dd9c19d (Feat: Add txId index suffix for transactions in batch (#587))
 
 /*
  * Test below verifies that the base class of TestGalaContract (i.e. GalaContract) provides stub to

--- a/chaincode/src/contracts/GalaContract.spec.ts
+++ b/chaincode/src/contracts/GalaContract.spec.ts
@@ -21,10 +21,19 @@ import {
   GalaChainResponse,
   GalaChainResponseType,
   GetObjectDto,
+<<<<<<< HEAD
   createValidChainObject,
   createValidDTO,
   serialize
+=======
+  PublicKey,
+  SigningScheme,
+  UserProfile,
+  createValidDTO,
+  signatures
+>>>>>>> cfe814e (Feat: Sandboxed stub in batch operations (#583))
 } from "@gala-chain/api";
+import { ChainUser } from "@gala-chain/client";
 import {
   TestChaincode,
   transactionError,
@@ -37,7 +46,15 @@ import { Context } from "fabric-contract-api";
 import { inspect } from "util";
 
 import TestGalaContract, { Superhero, SuperheroDto, SuperheroQueryDto } from "../__test__/TestGalaContract";
+<<<<<<< HEAD
 import { GalaChainContext } from "../types";
+=======
+import { GalaChainContext, createValidChainObject } from "../types";
+<<<<<<< HEAD
+import { PublicKeyContract } from "./PublicKeyContract";
+>>>>>>> cfe814e (Feat: Sandboxed stub in batch operations (#583))
+=======
+>>>>>>> dd9c19d (Feat: Add txId index suffix for transactions in batch (#587))
 
 /*
  * Test below verifies that the base class of TestGalaContract (i.e. GalaContract) provides stub to
@@ -385,12 +402,7 @@ describe("GalaContract.DryRun", () => {
       Status: GalaChainResponseType.Error,
       ErrorCode: 404,
       ErrorKey: "NOT_FOUND",
-      Message:
-        "Method UnknownMethod is not available. Available methods: " +
-        "BatchEvaluate, BatchSubmit, CreateSuperhero, DryRun, ErrorAfterPutKv, " +
-        "ErrorAfterPutNestedKv, GetChaincodeVersion, GetContractAPI, GetContractVersion, " +
-        "GetKv, GetNestedKv, GetObjectByKey, GetObjectHistory, " +
-        "GetSetPutNestedKv, PutKv, PutNestedKv, QuerySuperheroes"
+      Message: expect.stringContaining("Method UnknownMethod is not available")
     });
   });
 
@@ -620,4 +632,95 @@ describe("GalaContract.Batch", () => {
       ])
     );
   });
+
+  it("should reset writes occurring during unterminated async operation", async () => {
+    // Given
+    const chaincode = new TestChaincode([TestGalaContract]);
+    const batchSubmit = plainToInstance(BatchDto, {
+      operations: [
+        { method: "UnterminatedAsyncErrorOp", dto: { key: "test-key-1", text: "robot" } },
+        { method: "DelayedOp", dto: { key: "test-key-1", text: "human" } }
+      ],
+      writesLimit: 1000
+    });
+
+    // When
+    const response = await chaincode.invoke("TestGalaContract:BatchSubmit", batchSubmit.serialize());
+
+    // Then
+    expect(response).toEqual(
+      transactionSuccess([
+        transactionErrorMessageContains("Async operation was not awaited"),
+        transactionSuccess()
+      ])
+    );
+
+    // the check below fails - it's "robot"
+    expect(chaincode.state).toEqual({
+      "test-key-1": "human"
+    });
+  });
+
+  it("should get proper ctx data for transactions in batch", async () => {
+    // Given
+    const { user: user1, state: state1 } = await generateUser("user1");
+    const { user: user2, state: state2 } = await generateUser();
+
+    const signedDto = (u: ChainUser, uniqueKey: string) =>
+      plainToInstance(ChainCallDTO, { uniqueKey }).signed(u.privateKey);
+
+    const chaincode = new TestChaincode([TestGalaContract], { ...state1, ...state2 });
+
+    const batchSubmit = plainToInstance(BatchDto, {
+      operations: [
+        { method: "GetCtxData", dto: signedDto(user1, "test-key-1") },
+        { method: "GetCtxData", dto: signedDto(user2, "test-key-2") }
+      ]
+    });
+
+    // When
+    const response = await chaincode.invoke<GalaChainResponse<GalaChainResponse<unknown>[]>>(
+      "TestGalaContract:BatchSubmit",
+      batchSubmit.serialize()
+    );
+
+    // Then
+    const firstOperationResponse = response?.Data?.[0]?.Data as { txUnixTime: number; txId: string };
+
+    expect(response).toEqual(
+      transactionSuccess([
+        transactionSuccess({
+          callingUser: user1.identityKey,
+          txId: expect.stringMatching(/^[a-zA-Z0-9_-]+|0$/),
+          txUnixTime: expect.any(Number)
+        }),
+        transactionSuccess({
+          callingUser: user2.identityKey,
+          txId: firstOperationResponse.txId.replace("|0", "|1"),
+          txUnixTime: firstOperationResponse.txUnixTime
+        })
+      ])
+    );
+  });
 });
+
+async function generateUser(name?: string) {
+  const user = ChainUser.withRandomKeys(name);
+
+  const publicKey = await createValidChainObject(PublicKey, {
+    publicKey: signatures.normalizePublicKey(user.publicKey).toString("base64"),
+    signing: SigningScheme.ETH
+  });
+
+  const userProfile = await createValidChainObject(UserProfile, {
+    alias: user.identityKey,
+    ethAddress: user.ethAddress
+  });
+
+  const state = {
+    [`\u0000GCPK\u0000${user.identityKey}\u0000`]: publicKey.serialize(),
+    [`\u0000GCUP\u0000${user.ethAddress}\u0000`]: userProfile.serialize()
+  };
+
+  return { user, state };
+}

--- a/chaincode/src/contracts/GalaContract.ts
+++ b/chaincode/src/contracts/GalaContract.ts
@@ -189,18 +189,9 @@ export abstract class GalaContract extends Contract {
   })
   public async BatchSubmit(ctx: GalaChainContext, batchDto: BatchDto): Promise<GalaChainResponse<unknown>[]> {
     const responses: GalaChainResponse<unknown>[] = [];
-
-<<<<<<< HEAD
-    const writesLimit = Math.min(
-      batchDto.writesLimit ?? BatchDto.WRITES_DEFAULT_LIMIT,
-      BatchDto.WRITES_HARD_LIMIT
-    );
-    let writesCount = Object.keys(ctx.stub.getWrites()).length;
-=======
     const softWritesLimit = batchDto.writesLimit ?? BatchDto.WRITES_DEFAULT_LIMIT;
     const writesLimit = Math.min(softWritesLimit, BatchDto.WRITES_HARD_LIMIT);
     let writesCount = ctx.stub.getWritesCount();
->>>>>>> cfe814e (Feat: Sandboxed stub in batch operations (#583))
 
     for (const [index, op] of batchDto.operations.entries()) {
       // Use sandboxed context to avoid flushes of writes and deletes, and populate

--- a/chaincode/src/contracts/GalaContract.ts
+++ b/chaincode/src/contracts/GalaContract.ts
@@ -189,23 +189,27 @@ export abstract class GalaContract extends Contract {
   })
   public async BatchSubmit(ctx: GalaChainContext, batchDto: BatchDto): Promise<GalaChainResponse<unknown>[]> {
     const responses: GalaChainResponse<unknown>[] = [];
-    const aggregatedCache = {
-      writes: ctx.stub.getWrites(),
-      deletes: ctx.stub.getDeletes()
-    };
 
+<<<<<<< HEAD
     const writesLimit = Math.min(
       batchDto.writesLimit ?? BatchDto.WRITES_DEFAULT_LIMIT,
       BatchDto.WRITES_HARD_LIMIT
     );
     let writesCount = Object.keys(ctx.stub.getWrites()).length;
+=======
+    const softWritesLimit = batchDto.writesLimit ?? BatchDto.WRITES_DEFAULT_LIMIT;
+    const writesLimit = Math.min(softWritesLimit, BatchDto.WRITES_HARD_LIMIT);
+    let writesCount = ctx.stub.getWritesCount();
+>>>>>>> cfe814e (Feat: Sandboxed stub in batch operations (#583))
 
-    for (const op of batchDto.operations) {
-      // 1. Reset the calling user, to allow each operation to perform the
-      //    authorization.
-      ctx.resetCallingUser();
+    for (const [index, op] of batchDto.operations.entries()) {
+      // Use sandboxed context to avoid flushes of writes and deletes, and populate
+      // the stub with current writes and deletes.
+      const sandboxCtx = ctx.createReadOnlyContext(index);
+      sandboxCtx.stub.setWrites(ctx.stub.getWrites());
+      sandboxCtx.stub.setDeletes(ctx.stub.getDeletes());
 
-      // 2. Execute the operation. Collect both successful and failed responses.
+      // Execute the operation. Collect both successful and failed responses.
       let response: GalaChainResponse<unknown>;
       try {
         if (writesCount >= writesLimit) {
@@ -213,30 +217,19 @@ export abstract class GalaContract extends Contract {
         }
 
         const method = getApiMethod(this, op.method, (m) => m.isWrite && m.methodName !== "BatchSubmit");
-        response = await this[method.methodName](ctx, op.dto);
+        response = await this[method.methodName](sandboxCtx, op.dto);
       } catch (error) {
         response = GalaChainResponse.Error(error);
       }
       responses.push(response);
 
-      // 3. Update the cache.
-      //
-      //    If the operation is successful, we keep the changes. Otherwise, we
-      //    restore the cache to the previous state to prevent from having
-      //    cached writes that come from failed transactions.
-      //
-      //    At the end, we override the cache with the state without cached
-      //    reads to keep the cache small.
-      //
+      // Update the current context with the writes and deletes if the operation
+      // is successful.
       if (GalaChainResponse.isSuccess(response)) {
-        aggregatedCache.writes = ctx.stub.getWrites();
-        aggregatedCache.deletes = ctx.stub.getDeletes();
-        writesCount = Object.keys(aggregatedCache.writes).length;
-      } else {
-        ctx.stub.setWrites(aggregatedCache.writes);
-        ctx.stub.setDeletes(aggregatedCache.deletes);
+        ctx.stub.setWrites(sandboxCtx.stub.getWrites());
+        ctx.stub.setDeletes(sandboxCtx.stub.getDeletes());
+        writesCount = ctx.stub.getWritesCount();
       }
-      ctx.stub.setReads({});
     }
     return responses;
   }
@@ -253,22 +246,19 @@ export abstract class GalaContract extends Contract {
   ): Promise<GalaChainResponse<unknown>[]> {
     const responses: GalaChainResponse<unknown>[] = [];
 
-    for (const op of batchDto.operations) {
-      // 1. Reset the calling user, to allow each operation to perform the
-      //    authorization.
-      ctx.resetCallingUser();
+    for (const [index, op] of batchDto.operations.entries()) {
+      // Create a new context for each operation
+      const sandboxCtx = ctx.createReadOnlyContext(index);
 
-      // 2. Execute the operation. Collect both successful and failed responses.
+      // Execute the operation. Collect both successful and failed responses.
       let response: GalaChainResponse<unknown>;
       try {
         const method = getApiMethod(this, op.method, (m) => !m.isWrite && m.methodName !== "BatchEvaluate");
-        response = await this[method.methodName](ctx, op.dto);
+        response = await this[method.methodName](sandboxCtx, op.dto);
       } catch (error) {
         response = GalaChainResponse.Error(error);
       }
       responses.push(response);
-
-      // 3. We don't need to update the cache.
     }
     return responses;
   }

--- a/chaincode/src/types/GalaChainContext.ts
+++ b/chaincode/src/types/GalaChainContext.ts
@@ -69,12 +69,20 @@ export class GalaChainContext extends Context {
 
   get callingUser(): UserAlias {
     if (this.callingUserValue === undefined) {
+<<<<<<< HEAD
+<<<<<<< HEAD
       const message =
         "No calling user set. " +
         "It usually means that chaincode tried to get ctx.callingUser for unauthorized call (no DTO signature).";
       const error = new UnauthorizedError(message);
       console.error(error);
       throw new UnauthorizedError(message);
+=======
+      this.logger.error(new Error().stack ?? "No calling user set");
+=======
+>>>>>>> dd9c19d (Feat: Add txId index suffix for transactions in batch (#587))
+      throw new UnauthorizedError("No calling user set");
+>>>>>>> cfe814e (Feat: Sandboxed stub in batch operations (#583))
     }
     return this.callingUserValue;
   }
@@ -153,8 +161,19 @@ export class GalaChainContext extends Context {
     return this.txUnixTimeValue;
   }
 
+  /**
+   * @returns a new, empty context that uses the same chaincode stub as
+   * the current context, but with dry run set (disables writes and deletes).
+   */
+  public createReadOnlyContext(index: number | undefined): GalaChainContext {
+    const ctx = new GalaChainContext();
+    ctx.clientIdentity = this.clientIdentity;
+    ctx.setChaincodeStub(createGalaChainStub(this.stub, true, index));
+    return ctx;
+  }
+
   setChaincodeStub(stub: ChaincodeStub) {
-    const galaChainStub = createGalaChainStub(stub);
+    const galaChainStub = createGalaChainStub(stub, this.isDryRun, undefined);
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore - missing typings for `setChaincodeStub` in `fabric-contract-api`
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/chaincode/src/types/GalaChainContext.ts
+++ b/chaincode/src/types/GalaChainContext.ts
@@ -69,20 +69,10 @@ export class GalaChainContext extends Context {
 
   get callingUser(): UserAlias {
     if (this.callingUserValue === undefined) {
-<<<<<<< HEAD
-<<<<<<< HEAD
       const message =
         "No calling user set. " +
         "It usually means that chaincode tried to get ctx.callingUser for unauthorized call (no DTO signature).";
-      const error = new UnauthorizedError(message);
-      console.error(error);
       throw new UnauthorizedError(message);
-=======
-      this.logger.error(new Error().stack ?? "No calling user set");
-=======
->>>>>>> dd9c19d (Feat: Add txId index suffix for transactions in batch (#587))
-      throw new UnauthorizedError("No calling user set");
->>>>>>> cfe814e (Feat: Sandboxed stub in batch operations (#583))
     }
     return this.callingUserValue;
   }

--- a/chaincode/src/types/GalaChainStub.spec.ts
+++ b/chaincode/src/types/GalaChainStub.spec.ts
@@ -25,7 +25,7 @@ const setupTest = (initialState: Record<string, string> = {}) => {
 <<<<<<< HEAD
   /* eslint-disable  @typescript-eslint/ban-ts-comment */
   // @ts-ignore
-  const internalStub = new TestChaincodeStub([], state);
+  const internalStub = new TestChaincodeStub([], state, undefined);
   internalStub.putState = jest.fn(internalStub.putState);
   internalStub.getState = jest.fn(internalStub.getState);
   internalStub.deleteState = jest.fn(internalStub.deleteState);
@@ -33,19 +33,6 @@ const setupTest = (initialState: Record<string, string> = {}) => {
   internalStub.invokeChaincode = jest.fn(internalStub.invokeChaincode);
 
   const gcStub = createGalaChainStub(internalStub);
-=======
-  const testChaincodeStub = new TestChaincodeStub([], state, undefined);
-  testChaincodeStub.putState = jest.fn(testChaincodeStub.putState);
-  testChaincodeStub.getState = jest.fn(testChaincodeStub.getState);
-  testChaincodeStub.deleteState = jest.fn(testChaincodeStub.deleteState);
-  testChaincodeStub.getStateByPartialCompositeKey = jest.fn(testChaincodeStub.getStateByPartialCompositeKey);
-
-<<<<<<< HEAD
-  const cachedWrites = createGalaChainStub(testChaincodeStub, false);
->>>>>>> cfe814e (Feat: Sandboxed stub in batch operations (#583))
-=======
-  const cachedWrites = createGalaChainStub(testChaincodeStub, false, undefined);
->>>>>>> dd9c19d (Feat: Add txId index suffix for transactions in batch (#587))
 
   return { internalStub, gcStub };
 };

--- a/chaincode/src/types/GalaChainStub.spec.ts
+++ b/chaincode/src/types/GalaChainStub.spec.ts
@@ -22,7 +22,6 @@ import { DuplicateInvokeChaincodeError, createGalaChainStub } from "./GalaChainS
 const setupTest = (initialState: Record<string, string> = {}) => {
   const state = { ...initialState }; // shallow copy
 
-<<<<<<< HEAD
   /* eslint-disable  @typescript-eslint/ban-ts-comment */
   // @ts-ignore
   const internalStub = new TestChaincodeStub([], state, undefined);

--- a/chaincode/src/types/GalaChainStub.ts
+++ b/chaincode/src/types/GalaChainStub.ts
@@ -41,14 +41,11 @@ class StubCache {
 <<<<<<< HEAD
   private invokeChaincodeCalls: Record<string, string[]> = {};
 
-  constructor(private readonly stub: ChaincodeStub) {}
-=======
   constructor(
     private readonly stub: ChaincodeStub,
     private readonly isReadOnly: boolean,
     private readonly index: number | undefined
   ) {}
->>>>>>> cfe814e (Feat: Sandboxed stub in batch operations (#583))
 
   getTxID(): string {
     if (typeof this.index === "number") {
@@ -163,10 +160,6 @@ class StubCache {
   }
 
   async flushWrites(): Promise<void> {
-    if (this.isReadOnly) {
-      throw new NotImplementedError("Cannot flush writes in read-only mode");
-    }
-
     if (this.isReadOnly) {
       throw new NotImplementedError("Cannot flush writes in read-only mode");
     }

--- a/chaincode/src/types/GalaChainStub.ts
+++ b/chaincode/src/types/GalaChainStub.ts
@@ -38,7 +38,6 @@ class StubCache {
 
   private deletes: Record<string, true> = {};
 
-<<<<<<< HEAD
   private invokeChaincodeCalls: Record<string, string[]> = {};
 
   constructor(

--- a/chaincode/src/types/GalaChainStub.ts
+++ b/chaincode/src/types/GalaChainStub.ts
@@ -38,9 +38,24 @@ class StubCache {
 
   private deletes: Record<string, true> = {};
 
+<<<<<<< HEAD
   private invokeChaincodeCalls: Record<string, string[]> = {};
 
   constructor(private readonly stub: ChaincodeStub) {}
+=======
+  constructor(
+    private readonly stub: ChaincodeStub,
+    private readonly isReadOnly: boolean,
+    private readonly index: number | undefined
+  ) {}
+>>>>>>> cfe814e (Feat: Sandboxed stub in batch operations (#583))
+
+  getTxID(): string {
+    if (typeof this.index === "number") {
+      return this.stub.getTxID() + `|${this.index}`;
+    }
+    return this.stub.getTxID();
+  }
 
   async getCachedState(key: string): Promise<Uint8Array> {
     if (key in this.deletes) {
@@ -148,6 +163,14 @@ class StubCache {
   }
 
   async flushWrites(): Promise<void> {
+    if (this.isReadOnly) {
+      throw new NotImplementedError("Cannot flush writes in read-only mode");
+    }
+
+    if (this.isReadOnly) {
+      throw new NotImplementedError("Cannot flush writes in read-only mode");
+    }
+
     const deleteOps = Object.keys(this.deletes).map((key) => this.stub.deleteState(key));
     const putOps = Object.entries(this.writes).map(([key, value]) => this.stub.putState(key, value));
     await Promise.all(deleteOps);
@@ -160,6 +183,10 @@ class StubCache {
 
   getWrites(): Record<string, Uint8Array> {
     return { ...this.writes };
+  }
+
+  getWritesCount(): number {
+    return Object.keys(this.writes).length;
   }
 
   getDeletes(): Record<string, true> {
@@ -187,6 +214,8 @@ export class DuplicateInvokeChaincodeError extends NotImplementedError {
 }
 
 export interface GalaChainStub extends ChaincodeStub {
+  getTxID(): string;
+
   getCachedState(key: string): Promise<Uint8Array>;
 
   getCachedStateByPartialCompositeKey(objectType: string, attributes: string[]): FabricIterable<CachedKV>;
@@ -197,6 +226,8 @@ export interface GalaChainStub extends ChaincodeStub {
 
   getWrites(): Record<string, Uint8Array>;
 
+  getWritesCount(): number;
+
   getDeletes(): Record<string, true>;
 
   setReads(reads: Record<string, Uint8Array>): void;
@@ -206,8 +237,12 @@ export interface GalaChainStub extends ChaincodeStub {
   setDeletes(deletes: Record<string, true>): void;
 }
 
-export const createGalaChainStub = (stub: ChaincodeStub): GalaChainStub => {
-  const cachedWrites = new StubCache(stub);
+export const createGalaChainStub = (
+  stub: ChaincodeStub,
+  isReadOnly: boolean,
+  index: number | undefined
+): GalaChainStub => {
+  const cachedWrites = new StubCache(stub, isReadOnly, index);
 
   const proxyHandler = {
     get: function (target: GalaChainStub, name: string | symbol): unknown {


### PR DESCRIPTION
Here's a summary of what was included:

1.  **PR #583: Feat: Sandboxed stub in batch operations**
    *   This introduces a sandboxed stub for use in batch operations.
    *   The original merge commit was: `cfe814ee0968af8bd5dd279673ae31a3a3d8008a`

2.  **PR #587: Feat: Add txId index suffix for transactions in batch**
    *   This adds a `txId` index suffix for transactions included in a batch.
    *   The original merge commit (squash) was: `dd9c19d1a467bc2ae723b5918c95d59f8e271e99`

These changes were originally merged into the `main-v1` branch and have now been brought over to the `main` branch. I resolved any conflicts that arose during this process by prioritizing the changes from the pull requests.