### PR TITLE
Fix: Use actual channel ID in DuplicateInvokeChaincodeError

### DIFF
--- a/chaincode/src/types/GalaChainStub.ts
+++ b/chaincode/src/types/GalaChainStub.ts
@@ -125,7 +125,8 @@ class StubCache {
     const prevCall = this.invokeChaincodeCalls[key];
 
     if (prevCall) {
-      throw new DuplicateInvokeChaincodeError(chaincodeName, prevCall, channel);
+      const effectiveChannel = channel === "" ? this.stub.getChannelID() : channel;
+      throw new DuplicateInvokeChaincodeError(chaincodeName, prevCall, effectiveChannel);
     }
 
     this.invokeChaincodeCalls[key] = args;


### PR DESCRIPTION
When invoking chaincode, an empty string for the channel name signifies the current channel. The DuplicateInvokeChaincodeError message was previously displaying an empty channel name in such cases.

This change modifies the `invokeChaincode` method in `GalaChainStub.ts` to retrieve the channel ID if the provided `channel` parameter is empty. This ensures the error message accurately reflects the channel on which the duplicate invocation occurred.