### PR TITLE
Return reverseBondingCurveConfiguration in CreateSale response

### DIFF
--- a/chain-api/src/types/LaunchpadDtos.ts
+++ b/chain-api/src/types/LaunchpadDtos.ts
@@ -186,6 +186,11 @@ export class CreateSaleResDto {
   @IsString()
   @IsNotEmpty()
   public tokenStringKey: string;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ReverseBondingCurveConfigurationDto)
+  public reverseBondingCurveConfiguration?: ReverseBondingCurveConfigurationDto;
 }
 
 export class TokenExtraFeesDto {

--- a/chain-cli/chaincode-template/e2e/launchpad-api.spec.ts
+++ b/chain-cli/chaincode-template/e2e/launchpad-api.spec.ts
@@ -1911,6 +1911,8 @@ describe("LaunchpadContract", () => {
       expect(response).toEqual(transactionSuccess());
       expect(response.Data).toBeDefined();
       expect(response.Data?.vaultAddress).toBeTruthy();
+      expect(response.Data?.reverseBondingCurveConfiguration?.minFeePortion).toEqual(rbcConfig.minFeePortion);
+      expect(response.Data?.reverseBondingCurveConfiguration?.maxFeePortion).toEqual(rbcConfig.maxFeePortion);
 
       const saleVaultAddress = response.Data?.vaultAddress;
       if (!saleVaultAddress) return;

--- a/chaincode/src/launchpad/createSale.ts
+++ b/chaincode/src/launchpad/createSale.ts
@@ -150,6 +150,7 @@ export async function createSale(
     category: launchpadDetails.tokenCategory,
     functionName: "CreateSale",
     isFinalized: isSaleFinalised,
-    tokenStringKey: tokenInstanceKey.getTokenClassKey().toStringKey()
-  };
+    tokenStringKey: tokenInstanceKey.getTokenClassKey().toStringKey(),
+    reverseBondingCurveConfiguration: launchpadDetails.reverseBondingCurveConfiguration
+  } satisfies CreateSaleResDto;
 }


### PR DESCRIPTION
Small change to return the `reverseBondingCurveConfiguration` object in the response from CreateSale.