### PR TITLE
Feat: Terminate transaction with exception when external chaincode call succeeds and subsequent calls fail

### DIFF
--- a/chain-test/src/unit/fixture.ts
+++ b/chain-test/src/unit/fixture.ts
@@ -23,7 +23,7 @@ import {
   signatures
 } from "@gala-chain/api";
 import { Context, Contract } from "fabric-contract-api";
-import { ChaincodeStub } from "fabric-shim";
+import { ChaincodeResponse, ChaincodeStub } from "fabric-shim";
 import Logger from "fabric-shim/lib/logger";
 
 import { ChainUserWithRoles } from "../data/users";
@@ -65,6 +65,8 @@ type GalaChainStub = ChaincodeStub & {
   setReads(reads: Record<string, Uint8Array>): void;
   setWrites(writes: Record<string, Uint8Array>): void;
   setDeletes(deletes: Record<string, true>): void;
+  invokeChaincode(chaincodeName: string, args: string[], channel: string): Promise<ChaincodeResponse>;
+  get externalChaincodeWasInvoked(): boolean;
 };
 
 interface CallingUserData {

--- a/chaincode/src/types/GalaChainStub.spec.ts
+++ b/chaincode/src/types/GalaChainStub.spec.ts
@@ -447,4 +447,17 @@ describe("invokeChaincode", () => {
 
     expect(internalStub.invokeChaincode).toHaveBeenCalledTimes(3);
   });
+
+  it("should record external chaincode invocation", async () => {
+    // Given
+    const { gcStub } = setupTest();
+    const args = ["Contract:Method", "{}"];
+    expect(gcStub.externalChaincodeWasInvoked).toBe(false);
+
+    // When
+    await gcStub.invokeChaincode("chaincode-1", args, "channel-A");
+
+    // Then
+    expect(gcStub.externalChaincodeWasInvoked).toBe(true);
+  });
 });

--- a/chaincode/src/types/GalaChainStub.ts
+++ b/chaincode/src/types/GalaChainStub.ts
@@ -140,6 +140,10 @@ class StubCache {
     return await this.stub.invokeChaincode(chaincodeName, args, channel);
   }
 
+  get externalChaincodeWasInvoked(): boolean {
+    return Object.keys(this.invokeChaincodeCalls).length > 0;
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   setStateValidationParameter(key: string, ep: Uint8Array): Promise<void> {
     throw new NotImplementedError("setStateValidationParameter is not supported");
@@ -234,6 +238,10 @@ export interface GalaChainStub extends ChaincodeStub {
   setWrites(writes: Record<string, Uint8Array>): void;
 
   setDeletes(deletes: Record<string, true>): void;
+
+  invokeChaincode(chaincodeName: string, args: string[], channel: string): Promise<ChaincodeResponse>;
+
+  get externalChaincodeWasInvoked(): boolean;
 }
 
 export const createGalaChainStub = (


### PR DESCRIPTION
It addresses the case, when a submit operation is called on external chaincode, and after that call, the current chaincode fails. In such cases the only way to prevent from saving writes on chain by the external chaincode seems to be terminating the transaction with uncaught exception, and thus - not recording the transaction in history at all.