### PR TITLE
Docs: Reorganize authorization documentation

### DIFF
--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -45,6 +45,29 @@ sequenceDiagram
     deactivate Client app
 ```
 
+## Authentication and Authorization Flow
+
+The authentication and authorization process follows this sequence:
+
+1. **DTO Parsing and Validation**: The incoming DTO is parsed and validated
+2. **DTO Expiration Check**: If `dtoExpiresAt` is set, the system checks if the DTO has expired
+3. **User Authentication**:
+   - If `verifySignature` is enabled or a signature is present, the user is authenticated
+   - If no signature verification is required, default roles are assigned based on the authorization type
+4. **User Authorization**: The system checks if the authenticated user has the required roles, or organization membership, or is an allowed chaincode
+5. **Unique Key Enforcement**: For submit transactions, the system ensures the transaction has a unique key to prevent replay attacks
+6. **Transaction Execution**: The actual contract method is executed
+
+### Context Properties
+
+After successful authentication, the following context properties are available:
+
+- `ctx.callingUser`: The user's alias (e.g., `eth|0x123...def`, `client|admin`)
+- `ctx.callingUserEthAddress`: The user's Ethereum address (if available)
+- `ctx.callingUserTonAddress`: The user's TON address (if available)
+- `ctx.callingUserRoles`: Array of roles assigned to the user
+- `ctx.callingUserProfile`: Complete user profile object
+
 ## Signature based authorization
 
 Signature-based authorization uses secp256k1 signatures to verify the identity of the end user.
@@ -190,7 +213,7 @@ This way it is possible to get the current user's properties in the chaincode an
 
 By default, GalaChain does not allow anonymous users to access the chaincode.
 In order to access the chaincode, the user must be registered with the chaincode.
-This behaviour may be changed as described in the [Allowing non-registered users](#allowing-non-registered-users) section.
+This behaviour may be changed as described in the [Optional User Registration](#optional-user-registration) section.
 
 There are three methods to register a user:
 
@@ -226,29 +249,6 @@ The authentication mode is controlled by the `USE_RBAC` environment variable:
 
 See the [Registrar Organizations and REGISTRAR Role](#registrar-organizations-and-registrar-role) section for more details.
 
-#### Allowing non-registered users
-
-You may allow anonymous users to access the chaincode in one of the following ways:
-* setting the `ALLOW_NON_REGISTERED_USERS` environment variable to `true` for the chaincode container,
-* setting the `allowNonRegisteredUsers` property in the contract's `config` property to `true`, as shown in the example below:
-
-```typescript
-class MyContract extends GalaContract {
-  constructor() {
-    super("MyContract", version, {
-      allowNonRegisteredUsers: true
-    });
-  }
-}
-```
-
-It is useful especially when you expect a large number of users to access the chaincode, and you don't want to register all of them.
-
-If the non-registered users are allowed, the DTO needs to be signed with the user's private key, and the public key can be recovered from the signature.
-In this case, the user's alias will be `eth|<eth-addr>` or `ton|<ton-addr>`, and the user's roles will have default `EVALUATE` and `SUBMIT` roles.
-
-Registration is required only if you want to use the custom alias for the user in the chaincode, or if you want to provide custom roles for the user.
-
 ### Default admin user
 
 When the chaincode is deployed, it contains a default admin end user.
@@ -256,7 +256,19 @@ It is provided by two environment variables:
 * `DEV_ADMIN_PUBLIC_KEY` - it contains the admin user public key (sample: `88698cb1145865953be1a6dafd9646c3dd4c0ec3955b35d89676242129636a0b`).
 * `DEV_ADMIN_USER_ID` - it contains the admin user alias (sample: `client|admin`; this variable is optional),
 
-If the user profile is not found in the chain data, and the public key recovered from the signature is the same as the admin user public key (`DEV_ADMIN_PUBLIC_KEY`), the admin user is set as the calling user.
+Alternatively, you can provide a custom admin public key in the contract's configuration:
+
+```typescript
+class MyContract extends GalaContract {
+  constructor() {
+    super("MyContract", version, {
+      adminPublicKey: "88698cb1145865953be1a6dafd9646c3dd4c0ec3955b35d89676242129636a0b"
+    });
+  }
+}
+```
+
+If the user profile is not found in the chain data, and the public key recovered from the signature is the same as the admin user public key, the admin user is set as the calling user.
 Additionally, if the admin user alias is specified (`DEV_ADMIN_USER_ID`), it is used as the calling user alias.
 Otherwise, the default admin user alias is  `eth|<eth-addr-from-public-key>`.
 
@@ -362,25 +374,30 @@ If you want to call external chaincode and authorize your call as a chaincode:
 
 Remember to allow the chaincode in `allowedOriginChaincodes` transaction property in the target chaincode.
 
-## Authentication and Authorization Flow
+## Optional User Registration
 
-The authentication and authorization process follows this sequence:
+By default, GalaChain requires every user to be registered before they can interact with the chaincode. However, in scenarios with a large number of users, you might want to make user registration optional.
 
-1. **DTO Parsing and Validation**: The incoming DTO is parsed and validated
-2. **DTO Expiration Check**: If `dtoExpiresAt` is set, the system checks if the DTO has expired
-3. **User Authentication**: 
-   - If `verifySignature` is enabled or a signature is present, the user is authenticated
-   - If no signature verification is required, default roles are assigned based on the authorization type
-4. **User Authorization**: The system checks if the authenticated user has the required roles, or organization membership, or is an allowed chaincode
-5. **Unique Key Enforcement**: For submit transactions, the system ensures the transaction has a unique key to prevent replay attacks
-6. **Transaction Execution**: The actual contract method is executed
+You can allow non-registered users to access the chaincode in one of two ways:
 
-### Context Properties
+1.  **Environment Variable**: Set the `ALLOW_NON_REGISTERED_USERS` environment variable to `true` for the chaincode container.
 
-After successful authentication, the following context properties are available:
+    ```bash
+    ALLOW_NON_REGISTERED_USERS=true
+    ```
 
-- `ctx.callingUser`: The user's alias (e.g., `eth|0x123...def`, `client|admin`)
-- `ctx.callingUserEthAddress`: The user's Ethereum address (if available)
-- `ctx.callingUserTonAddress`: The user's TON address (if available)
-- `ctx.callingUserRoles`: Array of roles assigned to the user
-- `ctx.callingUserProfile`: Complete user profile object
+2.  **Contract Configuration**: Set the `allowNonRegisteredUsers` property to `true` in your contract's configuration.
+
+    ```typescript
+    class MyContract extends GalaContract {
+      constructor() {
+        super("MyContract", version, {
+          allowNonRegisteredUsers: true
+        });
+      }
+    }
+    ```
+
+When non-registered users are allowed, they still need to sign the DTO with their private key. The public key is recovered from the signature. In this case, the user's alias will be `eth|<eth-addr>` or `ton|<ton-addr>`, and they will be granted default `EVALUATE` and `SUBMIT` roles.
+
+Registration remains necessary if you need to assign custom aliases or roles to users.


### PR DESCRIPTION
- Moved 'Authentication and Authorization Flow' to be after the mermaid diagram.
- Added a new section 'Optional User Registration' at the end of the document.
- Updated the 'Default admin user' section to include information about custom admin public key configuration.
- Removed duplicated content and updated internal links.