### PR TITLE
Feat: Return history of the key in non-binary format

### DIFF
--- a/chain-api/src/types/dtos.spec.ts
+++ b/chain-api/src/types/dtos.spec.ts
@@ -70,7 +70,9 @@ it("should parse TestDtoWithArray", async () => {
   expect(await getPlainOrError(TestDtoWithArray, valid)).toEqual({ playerIds: ["123"] });
   expect(await getPlainOrError(TestDtoWithArray, invalid1)).toEqual(failedArrayMatcher);
   expect(await getPlainOrError(TestDtoWithArray, invalid2)).toEqual(failedArrayMatcher);
-  expect(await getPlainOrError(TestDtoWithArray, invalid3)).toEqual("Unexpected end of JSON input");
+  expect(await getPlainOrError(TestDtoWithArray, invalid3)).toEqual(
+    "Unterminated string in JSON at position 16 (line 1 column 17)"
+  );
 });
 
 it("should parse TestDtoWithBigNumber", async () => {

--- a/chaincode/src/utils/state.ts
+++ b/chaincode/src/utils/state.ts
@@ -307,7 +307,17 @@ export async function getObjectHistory(
 
   while (!res.done) {
     if (res.value) {
-      history.push(res.value);
+      const { isDelete, value, timestamp, txId } = res.value;
+
+      // `value` is a buffer, so we need to convert it to a string.
+      const stringValue = (value as unknown as Buffer).toString("utf8");
+
+      history.push({
+        isDelete,
+        timestamp,
+        txId,
+        value: stringValue
+      });
     }
     res = await iterator.next();
   }


### PR DESCRIPTION
The GetObjectHistory function would previously fail if a key's history contained a value that was not a valid JSON string. This was because it would attempt to parse the value regardless of its content.

This change ensures that the function returns the raw string value from the history, making the function more resilient to varied data types in an object's history.

Additionally, the response format has been updated to use camelCase for `isDelete` and `txId` to align with the existing API conventions.

closes #669