### PR TITLE
Fix: Mark optional oracle fetch DTO filters for whitelist validation

### DIFF
--- a/chain-api/src/types/oracle.spec.ts
+++ b/chain-api/src/types/oracle.spec.ts
@@ -17,8 +17,13 @@ import { plainToInstance } from "class-transformer";
 
 import { ExternalToken } from "./OraclePriceAssertion";
 import { TokenInstanceKey } from "./TokenInstance";
-import { createValidSubmitDTO } from "./dtos";
-import { OraclePriceAssertionDto, OraclePriceCrossRateAssertionDto } from "./oracle";
+import { createValidDTO, createValidSubmitDTO } from "./dtos";
+import {
+  FetchOracleAssertionsDto,
+  FetchOracleDefinitionsDto,
+  OraclePriceAssertionDto,
+  OraclePriceCrossRateAssertionDto
+} from "./oracle";
 
 describe("oracle.ts", () => {
   const mockOracle = "mock-oracle";
@@ -88,5 +93,35 @@ describe("oracle.ts", () => {
     mockAssertionDto.crossRate = new BigNumber("42");
 
     expect(mockAssertionDto.validateCrossRate).toThrow();
+  });
+
+  test("FetchOracleDefinitionsDto accepts optional name filter", async () => {
+    await expect(createValidDTO(FetchOracleDefinitionsDto, {})).resolves.toBeInstanceOf(
+      FetchOracleDefinitionsDto
+    );
+    await expect(
+      createValidDTO(FetchOracleDefinitionsDto, { name: "price-oracle-1", bookmark: "", limit: 10 })
+    ).resolves.toMatchObject({ name: "price-oracle-1", bookmark: "", limit: 10 });
+  });
+
+  test("FetchOracleAssertionsDto accepts optional oracle and identity filters", async () => {
+    await expect(createValidDTO(FetchOracleAssertionsDto, {})).resolves.toBeInstanceOf(
+      FetchOracleAssertionsDto
+    );
+    await expect(
+      createValidDTO(FetchOracleAssertionsDto, {
+        oracle: mockOracle,
+        identity: mockOracleIdentity,
+        txid: "abc",
+        bookmark: "next",
+        limit: 25
+      })
+    ).resolves.toMatchObject({
+      oracle: mockOracle,
+      identity: mockOracleIdentity,
+      txid: "abc",
+      bookmark: "next",
+      limit: 25
+    });
   });
 });

--- a/chain-api/src/types/oracle.ts
+++ b/chain-api/src/types/oracle.ts
@@ -18,6 +18,7 @@ import {
   ArrayNotEmpty,
   ArrayUnique,
   IsBoolean,
+  IsInt,
   IsNotEmpty,
   IsNumber,
   IsOptional,
@@ -62,16 +63,22 @@ export class FetchOracleDefinitionsDto extends ChainCallDTO {
   @JSONSchema({
     description: "(optional). Provide a name key to fetch a specific oracle definition"
   })
+  @IsOptional()
+  @IsString()
   name?: string | undefined;
 
   @JSONSchema({
     description: "(optional). Bookmark for paginated results"
   })
+  @IsOptional()
+  @IsString()
   bookmark?: string | undefined;
 
   @JSONSchema({
     description: "(optional). Limit results set."
   })
+  @IsOptional()
+  @IsInt()
   limit?: number | undefined;
 }
 
@@ -82,26 +89,36 @@ export class FetchOracleAssertionsDto extends ChainCallDTO {
   @JSONSchema({
     description: "(optional). Provide a oracle name key to fetch a specific oracle definition"
   })
+  @IsOptional()
+  @IsString()
   oracle?: string | undefined;
 
   @JSONSchema({
     description: "(optional). Filter by identity"
   })
+  @IsOptional()
+  @IsString()
   identity?: string | undefined;
 
   @JSONSchema({
     description: "(optional). Filter by a specific txid"
   })
+  @IsOptional()
+  @IsString()
   txid?: string | undefined;
 
   @JSONSchema({
     description: "(optional). Bookmark for paginated results"
   })
+  @IsOptional()
+  @IsString()
   bookmark?: string | undefined;
 
   @JSONSchema({
     description: "(optional). Limit results set."
   })
+  @IsOptional()
+  @IsInt()
   limit?: number | undefined;
 }
 


### PR DESCRIPTION
JSONSchema alone does not whitelist properties, so name/oracle/identity and pagination fields were rejected.